### PR TITLE
Add the Leiningen project root to the migration-dir search path

### DIFF
--- a/src/migratus/database.clj
+++ b/src/migratus/database.clj
@@ -77,10 +77,10 @@
 (defn create-name [id name direction]
   (str id "-" name "." direction ".sql"))
 
-(defn find-migration-dir [dir]
+(defn find-migration-dir [dir project-root]
   (first (filter #(.exists %)
                  (map #(io/file % dir)
-                      (cp/classpath-directories)))))
+                      (cons project-root (cp/classpath-directories))))))
 
 (defn find-migration-files [migration-dir]
   (->> (for [f (filter (fn [^File f]
@@ -117,9 +117,9 @@
                              :content (.toString w)}}})))
        (remove nil?)))
 
-(defn find-migrations [dir]
+(defn find-migrations [dir project-root]
   (->> (let [dir (ensure-trailing-slash dir)]
-         (if-let [migration-dir (find-migration-dir dir)]
+         (if-let [migration-dir (find-migration-dir dir project-root)]
            (find-migration-files migration-dir)
            (if-let [migration-jar (find-migration-jar dir)]
              (find-migration-resources dir migration-jar))))
@@ -142,7 +142,7 @@
                                                      default-table-name))]
        (doall (map :id results)))))
   (migrations [this]
-    (let [migrations (find-migrations (:migration-dir config))
+    (let [migrations (find-migrations (:migration-dir config) (:root config))
           table-name (:migration-table-name config default-table-name)]
       (for [[id mig] migrations
             :let [{:strs [up down]} mig]]


### PR DESCRIPTION
It's convention in RoR to put database migrations separate from the source and test code.  This patch adds the project dir to the head of the seq of directories in which migration-dir is searched for.
