### PR TITLE
Stopgap solution for clojure.java.jdbc 0.3.0 support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
   :aliases {"test!" ["do" "clean," "test"]}
   :dependencies [[org.clojure/clojure "1.2.1"]
                  [org.clojure/java.classpath "0.1.0"]
-                 [org.clojure/java.jdbc "0.2.3"]
+                 [org.clojure/java.jdbc "0.3.0"]
                  [org.clojure/tools.logging "0.2.3"]
                  [robert/bruce "0.7.1"]]
   :dev-dependencies [[jar-migrations "1.0.0"]

--- a/src/migratus/database.clj
+++ b/src/migratus/database.clj
@@ -13,7 +13,7 @@
 ;;;; under the License.
 (ns migratus.database
   (:require [clojure.java.io :as io]
-            [clojure.java.jdbc :as sql]
+            [clojure.java.jdbc.deprecated :as sql]
             [clojure.java.classpath :as cp]
             [clojure.tools.logging :as log]
             [migratus.protocols :as proto])


### PR DESCRIPTION
This is a stopgap; we're still using the old, deprecated API. The only change is to point to said API at its new name in 0.3.0.
