### PR TITLE
Fixed typographical error, changed accomodate to accommodate in README.

### DIFF
--- a/README.org
+++ b/README.org
@@ -17,7 +17,7 @@
      recommended that they be timestamps (e.g. '20111202091200').
   2. Migrations are considered for completion independently.
 
-  Using a 14 digit timestamp will accomodate migrations granularity to a second,
+  Using a 14 digit timestamp will accommodate migrations granularity to a second,
   reducing the chance of collisions for a distributed team.
 
   In contrast, using a single global version for a store and incremented


### PR DESCRIPTION
@yogthos, I've corrected a typographical error in the documentation of the [migratus](https://github.com/yogthos/migratus) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.