### PR TITLE
remove try-try-again

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,6 @@
                  [org.clojure/java.classpath "0.2.2"]
                  [org.clojure/java.jdbc "0.3.7"]
                  [org.clojure/tools.logging "0.3.1"]
-                 [robert/bruce "0.7.1"]
                  [camel-snake-kebab "0.3.2"]]
   :profiles {:dev {:dependencies [[jar-migrations "1.0.0"]
                                   [log4j "1.2.17"]

--- a/src/migratus/database.clj
+++ b/src/migratus/database.clj
@@ -17,7 +17,6 @@
             [clojure.java.classpath :as cp]
             [clojure.tools.logging :as log]
             [migratus.protocols :as proto]
-            [robert.bruce :refer [try-try-again]]
             [camel-snake-kebab.core :as camel-snake-kebab])
   (:import [java.io File StringWriter]
            java.util.Date
@@ -148,13 +147,11 @@
     name)
   (up [this]
     (if up
-      (try-try-again {:sleep 1000 :tries 3 :decay :exponential}
-                     up* db table-name id up)
+      (up* db table-name id up)
       (throw (Exception. (format "Up commands not found for %d" id)))))
   (down [this]
     (if down
-      (try-try-again {:sleep 1000 :tries 3 :decay :exponential}
-                     down* db table-name id down)
+      (down* db table-name id down)
       (throw (Exception. (format "Down commands not found for %d" id))))))
 
 (defn connect* [db]


### PR DESCRIPTION
I don't know the context of why this library was been used. But this method will eat the exception, and try to run a migration twice, which might be dangerous. There are two issues related to it:

This happens if a migration has multiple commands and a syntax error on the last command.

https://github.com/yogthos/migratus/issues/31
https://github.com/yogthos/migratus/issues/48

There are other problems that needs to be looked into on those issues, but we can understand that migrations are been executed twice.

What do you think?