### PR TITLE
Fix sqlite DROP TABLE migration error

### DIFF
--- a/src/migratus/database.clj
+++ b/src/migratus/database.clj
@@ -190,6 +190,7 @@
       .getMetaData
       (.getTables (.getCatalog conn) nil table-name nil)
       sql/result-set-seq
+      doall
       not-empty
       boolean))
 


### PR DESCRIPTION
When using sqlite, any migration containing a `DROP TABLE` statement fails with the error "[SQLITE_LOCKED]  A table in the database is locked (database table is locked)". This error only occurs if the `schema_migrations` table already exists.

It appears to be related to the `find-table` function. The best I can come up with is since results are lazy and not fully evaluated, the ResultSet is not closed.

Adding `doall` corrects the problem. Tested change on sqlite, postgresql, mysql.