### PR TITLE
Create a migration directory if we can't find it

### DIFF
--- a/src/migratus/database.clj
+++ b/src/migratus/database.clj
@@ -81,6 +81,19 @@
        (filter #(.exists %))
        first))
 
+(def default-migration-parent
+  "resources/")
+
+(defn find-or-create-migration-dir [dir]
+  (if-let [migration-dir (find-migration-dir dir)]
+    migration-dir
+
+    ;; Couldn't find the migration dir, create it
+    (let [new-migration-dir (io/file default-migration-parent dir)]
+      (io/make-parents new-migration-dir ".")
+      new-migration-dir)))
+
+
 (defn find-migration-files [migration-dir]
   (->> (for [f (filter (fn [^File f]
                          (.isFile f)) (file-seq migration-dir))
@@ -228,7 +241,7 @@
                  (:migration-dir config)
                  (migration-table-name config)))
   (create [this name]
-    (let [migration-dir (find-migration-dir (:migration-dir config))
+    (let [migration-dir (find-or-create-migration-dir (:migration-dir config))
           migration-name (camel-snake-kebab/->kebab-case (str (timestamp) name))
           migration-up-name (str migration-name ".up.sql")
           migration-down-name (str migration-name ".down.sql")]


### PR DESCRIPTION
Defaults to being under "resources/"

Closes #57 