### PR TITLE
Respect current schema.

### DIFF
--- a/src/migratus/database.clj
+++ b/src/migratus/database.clj
@@ -219,7 +219,7 @@
 (defn find-table [conn table-name]
   (-> conn
       .getMetaData
-      (.getTables (.getCatalog conn) nil table-name nil)
+      (.getTables (.getCatalog conn) (.getSchema conn) table-name nil)
       sql/result-set-seq
       doall
       not-empty


### PR DESCRIPTION
When checking if a table exists (table-exists?) the connection schema
should be respected otherwise it will return true for any matching table
name across all schemas.

Compatibility Note: This will break migration for anyone who was
dependent on the global search, they should be able to resolve this by
including the target namespace via :migration-table-name