### PR TITLE
Add modify sql hook

### DIFF
--- a/README.org
+++ b/README.org
@@ -169,6 +169,13 @@ Migratus provides a Leiningen plugin:
     See test/migrations in this repository for an example of how database
     migrations work.
 
+*** Modify sql fn
+If you want to do some processing of the sql before it gets executed, you can
+provide a `:modify-sql-fn` in the config data structure to do so. This is
+intended for use with http://2ndquadrant.com/en/resources/pglogical/ and similar
+systems, where DDL statements need to be executed via an extension-provided
+function.
+
 ** Usage
    Migratus can be used programmatically by calling one of the following
    functions:

--- a/src/migratus/database.clj
+++ b/src/migratus/database.clj
@@ -64,11 +64,11 @@
        (remove empty?)
        (not-empty)))
 
-(defn up* [db table-name id up]
+(defn up* [db table-name id up modify-sql-fn]
   (sql/with-db-transaction
     [t-con db]
     (when-not (complete? t-con table-name id)
-      (when-let [commands (split-commands up)]
+      (when-let [commands (map modify-sql-fn (split-commands up))]
         (log/debug "found" (count commands) "up migrations")
         (doseq [c commands]
           (log/trace "executing" c)
@@ -80,11 +80,11 @@
         (mark-complete t-con table-name id)
         true))))
 
-(defn down* [db table-name id down]
+(defn down* [db table-name id down modify-sql-fn]
   (sql/with-db-transaction
     [t-con db]
     (when (complete? db table-name id)
-      (when-let [commands (split-commands down)]
+      (when-let [commands (map modify-sql-fn (split-commands down))]
         (log/debug "found" (count commands) "down migrations")
         (doseq [c commands]
           (log/trace "executing" c)
@@ -172,7 +172,7 @@
     (catch Exception e
       (log/error e (str "failed to parse migration id: " id)))))
 
-(defrecord Migration [db table-name id name up down]
+(defrecord Migration [db table-name id name up down modify-sql-fn]
   proto/Migration
   (id [this]
     id)
@@ -180,11 +180,11 @@
     name)
   (up [this]
     (if up
-      (up* db table-name id up)
+      (up* db table-name id up modify-sql-fn)
       (throw (Exception. (format "Up commands not found for %d" id)))))
   (down [this]
     (if down
-      (down* db table-name id down)
+      (down* db table-name id down modify-sql-fn)
       (throw (Exception. (format "Down commands not found for %d" id))))))
 
 (defn connect* [db]
@@ -208,7 +208,7 @@
          (map :id)
          (doall))))
 
-(defn migrations* [db migration-dir table-name]
+(defn migrations* [db migration-dir table-name modify-sql-fn]
   (for [[id mig] (find-migrations migration-dir)
         :let [{:strs [up down]} mig]]
     (Migration. db
@@ -216,7 +216,8 @@
                 (parse-migration-id (or (:id up) (:id down)))
                 (or (:name up) (:name down))
                 (:content up)
-                (:content down))))
+                (:content down)
+                modify-sql-fn)))
 
 (defn method-exists? [obj method-name]
   (->> (.getClass obj)
@@ -263,7 +264,8 @@
   (migrations [this]
     (migrations* @(:connection config)
                  (:migration-dir config)
-                 (migration-table-name config)))
+                 (migration-table-name config)
+                 (get config :modify-sql-fn identity)))
   (create [this name]
     (let [migration-dir (find-or-create-migration-dir (:migration-dir config))
           migration-name (->kebab-case (str (timestamp) name))

--- a/test/migratus/test/database.clj
+++ b/test/migratus/test/database.clj
@@ -157,3 +157,19 @@
   (is (verify-table-exists? config "bar"))
   (is (verify-table-exists? config "quux"))
   (is (verify-table-exists? config "quux2")))
+
+(defn comment-out-bar-statements [sql]
+  (if (re-find #"bar" sql)
+    (str "-- " sql)
+    sql))
+
+(deftest test-migrate-with-modify-sql-fn
+  (is (not (verify-table-exists? config "foo")))
+  (is (not (verify-table-exists? config "bar")))
+  (is (not (verify-table-exists? config "quux")))
+  (is (not (verify-table-exists? config "quux2")))
+  (core/migrate (assoc config :modify-sql-fn comment-out-bar-statements))
+  (is (verify-table-exists? config "foo"))
+  (is (not (verify-table-exists? config "bar")))
+  (is (verify-table-exists? config "quux"))
+  (is (verify-table-exists? config "quux2")))


### PR DESCRIPTION
Add a :modify-sql-fn key to the config map. If a function is provided
here, it will be called for each user-provided sql statement before it
is executed. If :modify-sql-fn is not provided, the identity function is
used so no change is applied.

This is intended for use with
http://2ndquadrant.com/en/resources/pglogical/ and similar systems,
where DDL statements need to be executed via an extension-provided
function. An application can then conditionally provide a modify-sql-fn, if 
it seems that the extension is present. 