### PR TITLE
Make the unclompleted-migrations function public

### DIFF
--- a/src/migratus/core.clj
+++ b/src/migratus/core.clj
@@ -35,7 +35,7 @@
   (let [plugin (symbol (str "migratus." (name store)))]
     (require plugin)))
 
-(defn- uncompleted-migrations [store]
+(defn uncompleted-migrations [store]
   (let [completed? (set (proto/completed-ids store))]
     (remove (comp completed? proto/id) (proto/migrations store))))
 


### PR DESCRIPTION
This commit makes the uncompleted-migrations function public. This
allows a user to check the list of pending migrations for a database as
part of migratus' public interface (rather than pending-migrations which
returns a string of all the pending migrations).