### PR TITLE
Better existence check for schema_migrations table

### DIFF
--- a/src/migratus/database.clj
+++ b/src/migratus/database.clj
@@ -246,7 +246,7 @@
                 (:content down)
                 modify-sql-fn)))
 
-(defn- table-exists?
+(defn table-exists?
   "Checks whether the migrations table exists, by attempting to select from
   it. Note that this appears to be the only truly portable way to determine
   whether the table exists in a schema which the `db` configuration will find


### PR DESCRIPTION
Checking by seeing if the DatabaseMetaData lists a `schema_migrations`
table doesn't reliably tell you whether `SELECT FROM schema_migrations`
and `INSERT INTO schema_migrations` will succeed, since that depends on
how the database resolves schemas.