### PR TITLE
Mark migration as complete before the transaction

### DIFF
--- a/src/migratus/core.clj
+++ b/src/migratus/core.clj
@@ -52,8 +52,9 @@
       (log/info "Running up for" (pr-str (vec (map proto/id migrations))))
       (loop [[migration & more] migrations]
         (when migration
-          (if (up* migration)
-            (recur more)
+          (case (up* migration)
+            :success (recur more)
+            :ignore (log/info "Migration reserved by another instance. Ignoring.")
             (log/error "Stopping:" (migration-name migration) "failed to migrate")))))))
 
 (defn- migrate* [store _]

--- a/test/migratus/mock.clj
+++ b/test/migratus/mock.clj
@@ -21,7 +21,8 @@
   (name [this]
     name)
   (up [this]
-    (swap! ups conj id))
+    (swap! ups conj id)
+    :success)
   (down [this]
     (swap! downs conj id)))
 

--- a/test/migratus/mock.clj
+++ b/test/migratus/mock.clj
@@ -24,7 +24,8 @@
     (swap! ups conj id)
     :success)
   (down [this]
-    (swap! downs conj id)))
+    (swap! downs conj id)
+    :success))
 
 (defrecord MockStore [completed-ids migrations]
   proto/Store


### PR DESCRIPTION
Addresses #94.

I've changed the semantics of `mark-complete` slightly so that a successful insert returns true, and false otherwise (where before it threw an exception on duplicate key). Only when the row has been inserted successfully will the migration proceed. If `mark-complete` returns false then the instance will stop running migrations.

One caveat is that when other instances try to apply migrations to databases that _do_ support transactional DDL, they will emit [this error message](https://github.com/yogthos/migratus/blob/master/src/migratus/core.clj#L57) where before it was the transaction that blocked. One solution could be to return a keyword from `up*` ( `:success`, `:failed` or `:ignore`), the value of which determines whether we apply the next migration, log an error as before, or exit, respectively.

Feedback much appreciated. Thanks!