### PR TITLE
Update find-init-script-resource to use clojure.java.io.

### DIFF
--- a/src/migratus/database.clj
+++ b/src/migratus/database.clj
@@ -201,9 +201,13 @@
             (file-seq migration-dir))))
 
 (defn find-init-script-resource [migration-dir jar init-script-name]
-  (first
-    (filter (fn [^JarEntry entry] (= (.getName ^JarEntry entry) init-script-name))
-            (enumeration-seq (.entries jar)))))
+  (->> (.entries jar)
+       (enumeration-seq)
+       (filter (fn [^JarEntry entry]
+                 (= (.getName ^JarEntry entry) init-script-name)))
+       (first)
+       (.getName)
+       (io/resource)))
 
 (defn find-init-script [dir init-script-name]
   (let [dir (ensure-trailing-slash dir)]


### PR DESCRIPTION
Fixes #63

I wanted to change as little as possible, so I simply used the existing function and added a few more wrapping functions to the chain in order to get the resource object.

I have tested this on completely isolated .jar files of our project (inside Docker containers, no access to the project source code) with init scripts in the following locations:

* `resources/init.sql`
* `resources/db/init.sql`

I did not test against `resources/migrations/init.sql`.

Note that we needed this fix for a deployment at NASA, so I've pushed a fixed artifact up to Clojars; we'll switch to the next official release of Migratus that includes a fix for this (it doesn't have to be our fix :-)).