### PR TITLE
Support code-based migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ pom.xml
 /target/
 .lein-failures
 .lein-deps-sum
+.lein-repl-history
+.nrepl-port
 /test/log4j.properties
 *.log
 .idea

--- a/README.org
+++ b/README.org
@@ -5,7 +5,8 @@
 
   [[https://cdn.rawgit.com/yogthos/migratus/master/migrate.png]]
 
-  A general migration framework, with an implementation for database migrations.
+  A general migration framework, with implementations for migrations as SQL
+  scripts or general Clojure code.
 
   Designed to be compatible with a git based work flow where multiple topic
   branches may exist simultaneously, and be merged into a master branch in
@@ -129,6 +130,73 @@ This will result with up/down migration files being created prefixed with the cu
 
      : 20150701134958-create-user.up.sql
      : 20150701134958-create-user.down.sql
+
+** Code-based Migrations
+
+   Application developers often encounter situations where migrations
+   cannot be easily expressed as a SQL script. For instance:
+
+   - Executing programmatically-generated DDL statements
+     (e.g. updating the schema of a dynamically-sharded table).
+   - Transferring data between database servers.
+   - Backfilling existing records with information that must be
+     retrieved from an external system.
+
+   A common approach in these scenarios is to write one-off scripts
+   which an admin must manually apply for each instance of the
+   application, but issues arise if a script is not run or run
+   multiple times.
+
+   Migratus addresses this problem by providing support for code-based
+   migrations. You can write a migration as a Clojure function, and
+   Migratus will ensure that it's run exactly once for each instance
+   of the application.
+
+*** Defining a code-based migration
+
+    Create a code-based migration by adding a =.edn= file to your
+    migrations directory that contains the namespace and up/down
+    functions to run,
+    e.g. =resources/migrations/20170331141500-import-users.edn=:
+
+    : {:ns app.migrations.import-users
+    :  :up-fn migrate-up
+    :  :down-fn migrate-down}
+
+    Then, in =src/app/migrations/import_users.clj=:
+
+    : (ns app.migrations.import-users)
+    :
+    : (defn migrate-up [config]
+    :   ;; do stuff here
+    :   )
+    :
+    : (defn migrate-down [config]
+    :   ;; maybe undo stuff here
+    :   )
+
+    - The up and down migration functions should both accept a single
+      parameter, which is the config map passed to Migratus (so your
+      migrations can be configurable).
+    - You can omit the up or down migration by setting =:up-fn= or
+      =down-fn= to =nil= in the EDN file.
+
+*** Generate code-based migration files
+
+    The =migratus.core/create= function accepts an optional type
+    parameter, which you can pass as =:edn= to create a new migration
+    file.
+
+    : (migratus/create config "import-users" :edn)
+
+*** Mixing SQL and code-based migrations
+
+    You can include both SQL and code-based migrations in the same
+    migrations directory, in which case they will be run intermixed in
+    the order defined by their timestamps and their status stored in
+    the same table in the migrations database. This way if there are
+    dependencies between your SQL and code-based migrations, you can
+    be assured that they'll run in the correct order.
 
 ** Quick Start (Leiningen 2.x)
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject migratus "0.8.33"
+(defproject migratus "0.9.0-SNAPSHOT"
   :description "MIGRATE ALL THE THINGS!"
   :url "http://github.com/yogthos/migratus"
   :license {:name "Apache License, Version 2.0"

--- a/src/migratus/core.clj
+++ b/src/migratus/core.clj
@@ -14,6 +14,7 @@
 (ns migratus.core
   (:require [clojure.set :as set]
             [clojure.tools.logging :as log]
+            [migratus.migrations :as mig]
             [migratus.protocols :as proto]
             migratus.database))
 
@@ -36,7 +37,7 @@
 
 (defn uncompleted-migrations [config store]
   (let [completed? (set (proto/completed-ids store))]
-    (remove (comp completed? proto/id) (migratus.database/list-migrations config))))
+    (remove (comp completed? proto/id) (mig/list-migrations config))))
 
 (defn migration-name [migration]
   (str (proto/id migration) "-" (proto/name migration)))
@@ -70,7 +71,7 @@
 (defn- run-up [config store ids]
   (let [completed (set (proto/completed-ids store))
         ids (set/difference (set ids) completed)
-        migrations (filter (comp ids proto/id) (migratus.database/list-migrations config))]
+        migrations (filter (comp ids proto/id) (mig/list-migrations config))]
     (migrate-up* store migrations)))
 
 (defn up
@@ -83,7 +84,7 @@
   (let [completed (set (proto/completed-ids store))
         ids (set/intersection (set ids) completed)
         migrations (filter (comp ids proto/id)
-                           (migratus.database/list-migrations config))
+                           (mig/list-migrations config))
         migrations (reverse (sort-by proto/id migrations))]
     (when (seq migrations)
       (log/info "Running down for" (pr-str (vec (map proto/id migrations))))
@@ -129,12 +130,12 @@
 (defn create
   "Create a new migration with the current date"
   [config & [name]]
-  (migratus.database/create config name))
+  (mig/create config name))
 
 (defn destroy
   "Destroy migration"
   [config & [name]]
-  (migratus.database/destroy config name))
+  (mig/destroy config name))
 
 (defn pending-list
   "List pending migrations"

--- a/src/migratus/core.clj
+++ b/src/migratus/core.clj
@@ -129,8 +129,8 @@
 
 (defn create
   "Create a new migration with the current date"
-  [config & [name]]
-  (mig/create config name))
+  [config & [name type]]
+  (mig/create config name (or type :sql)))
 
 (defn destroy
   "Destroy migration"

--- a/src/migratus/database.clj
+++ b/src/migratus/database.clj
@@ -75,7 +75,7 @@
        (remove empty?)
        (not-empty)))
 
-(defn execute-command [t-con table-name c id]
+(defn execute-command [t-con c id]
   (log/trace "executing" c)
   (try
     (sql/db-do-prepared t-con c)
@@ -92,7 +92,7 @@
           (when-let [commands (map modify-sql-fn (split-commands up))]
             (log/debug "found" (count commands) "up migrations")
             (doseq [c commands]
-              (execute-command t-con table-name c id))
+              (execute-command t-con c id))
             (mark-complete t-con table-name id)
             :success)))
       (finally

--- a/src/migratus/database.clj
+++ b/src/migratus/database.clj
@@ -75,7 +75,7 @@
         (sql/with-db-transaction
           [t-con db]
           (when-not (complete? t-con table-name id)
-            (proto/up migration config)
+            (proto/up migration (assoc config :conn t-con))
             (mark-complete t-con table-name id)
             :success))
         (finally
@@ -91,7 +91,7 @@
         (sql/with-db-transaction
           [t-con db]
           (when (complete? t-con table-name id)
-            (proto/down migration config)
+            (proto/down migration (assoc config :conn t-con))
             (mark-not-complete t-con table-name id)
             :success))
         (finally

--- a/src/migratus/migration/edn.clj
+++ b/src/migratus/migration/edn.clj
@@ -1,0 +1,55 @@
+(ns migratus.migration.edn
+  "Support for EDN migration files that specify clojure code migrations."
+  (:require [clojure.edn :as edn]
+            [migratus.protocols :as proto]))
+
+;; up-fn and down-fn here are actually vars; invoking them as fns will deref
+;; them and invoke the fn bound by the var.
+(defrecord EdnMigration [id name up-fn down-fn]
+  proto/Migration
+  (id [this] id)
+  (name [this] name)
+  (up [this config]
+    (when up-fn
+      (up-fn config)))
+  (down [this config]
+    (when down-fn
+      (down-fn config))))
+
+(defn to-sym
+  "Converts x to a non-namespaced symbol, throwing if x is namespaced"
+  [x]
+  (let [validate #(if (and (instance? clojure.lang.Named %)
+                           (namespace %))
+                    (throw (IllegalArgumentException.
+                            (str "Namespaced symbol not allowed: " %)))
+                    %)]
+    ;; validate on input to catch namespaced symbols/keywords, and on output
+    ;; to catch strings that parse as a namespaced symbol e.g. "foo/bar"
+    (some-> x validate name symbol validate)))
+
+(defn resolve-fn
+  "Basically ns-resolve with some error-checking"
+  [mig-name mig-ns fn-name]
+  (when fn-name
+    (or (ns-resolve mig-ns (to-sym fn-name))
+        (throw (IllegalArgumentException.
+                (format "Unable to resolve %s/%s for migration %s"
+                        mig-ns fn-name mig-name))))))
+
+(defmethod proto/make-migration* :edn
+  [_ mig-id mig-name payload config]
+  (let [{:keys [ns up-fn down-fn]
+         :or {up-fn "up" down-fn "down"}} (edn/read-string payload)
+        mig-ns (to-sym ns)]
+    (when-not mig-ns
+      (throw (IllegalArgumentException.
+              (format "Invalid migration %s: no namespace" mig-name))))
+    (require mig-ns)
+    (->EdnMigration mig-id mig-name
+                    (resolve-fn mig-name mig-ns up-fn)
+                    (resolve-fn mig-name mig-ns down-fn))))
+
+(defmethod proto/migration-files* :edn
+  [_ migration-name]
+  [(str migration-name ".edn")])

--- a/src/migratus/migration/sql.clj
+++ b/src/migratus/migration/sql.clj
@@ -53,3 +53,8 @@
 (defmethod proto/make-migration* :sql
   [_ mig-id mig-name payload config]
   (->SqlMigration mig-id mig-name (:up payload) (:down payload)))
+
+(defmethod proto/migration-files* :sql
+  [_ migration-name]
+  [(str migration-name ".up.sql")
+   (str migration-name ".down.sql")])

--- a/src/migratus/migration/sql.clj
+++ b/src/migratus/migration/sql.clj
@@ -49,3 +49,7 @@
     (if down
       (run-sql config down :down)
       (throw (Exception. (format "Down commands not found for %d" id))))))
+
+(defmethod proto/make-migration* :sql
+  [_ mig-id mig-name payload config]
+  (->SqlMigration mig-id mig-name (:up payload) (:down payload)))

--- a/src/migratus/migration/sql.clj
+++ b/src/migratus/migration/sql.clj
@@ -1,0 +1,51 @@
+(ns migratus.migration.sql
+  (:require [clojure.java.jdbc :as sql]
+            [clojure.tools.logging :as log]
+            [migratus.protocols :as proto])
+  (:import java.util.regex.Pattern))
+
+(def sep (Pattern/compile "^.*--;;.*\r?\n" Pattern/MULTILINE))
+(def sql-comment (Pattern/compile "^--.*" Pattern/MULTILINE))
+(def empty-line (Pattern/compile "^[ ]+" Pattern/MULTILINE))
+
+(defn sanitize [command]
+  (-> command
+      (clojure.string/replace sql-comment "")
+      (clojure.string/replace empty-line "")))
+
+(defn split-commands [commands]
+  (->> (.split sep commands)
+       (map sanitize)
+       (remove empty?)
+       (not-empty)))
+
+(defn execute-command [t-con c]
+  (log/trace "executing" c)
+  (try
+    (sql/db-do-prepared t-con c)
+    (catch Throwable t
+      (log/error t "failed to execute command:\n" c "\n")
+      (throw t))))
+
+(defn run-sql [{:keys [conn db modify-sql-fn]} sql direction]
+  (sql/with-db-transaction
+    [t-con (or conn db)]
+    (when-let [commands (map (or modify-sql-fn identity) (split-commands sql))]
+      (log/debug "found" (count commands) (name direction) "migrations")
+      (doseq [c commands]
+        (execute-command t-con c)))))
+
+(defrecord SqlMigration [id name up down]
+  proto/Migration
+  (id [this]
+    id)
+  (name [this]
+    name)
+  (up [this config]
+    (if up
+      (run-sql config up :up)
+      (throw (Exception. (format "Up commands not found for %d" id)))))
+  (down [this config]
+    (if down
+      (run-sql config down :down)
+      (throw (Exception. (format "Down commands not found for %d" id))))))

--- a/src/migratus/migrations.clj
+++ b/src/migratus/migrations.clj
@@ -124,18 +124,16 @@
                                    (utils/get-exclude-scripts config))]
      (make-migration config id mig))))
 
-(defn create [config name]
+(defn create [config name migration-type]
   (let [migration-dir (find-or-create-migration-dir (get-migration-dir config))
-        migration-name (->kebab-case (str (timestamp) name))
-        migration-up-name (str migration-name ".up.sql")
-        migration-down-name (str migration-name ".down.sql")]
-    (.createNewFile (File. migration-dir migration-up-name))
-    (.createNewFile (File. migration-dir migration-down-name))))
+        migration-name (->kebab-case (str (timestamp) name))]
+    (doseq [mig-file (proto/migration-files* migration-type migration-name)]
+      (.createNewFile (io/file migration-dir mig-file)))))
 
 (defn destroy [config name]
   (let [migration-dir (utils/find-migration-dir (get-migration-dir config))
         migration-name (->kebab-case name)
-        pattern (re-pattern (str "[\\d]*-" migration-name ".*.sql"))
+        pattern (re-pattern (str "[\\d]*-" migration-name "\\..*"))
         migrations (file-seq migration-dir)]
     (doseq [f (filter #(re-find pattern (.getName %)) migrations)]
       (.delete f))))

--- a/src/migratus/migrations.clj
+++ b/src/migratus/migrations.clj
@@ -30,10 +30,6 @@
   (let [fmt (SimpleDateFormat. "yyyyMMddHHmmss ")]
     (.format fmt (Date.))))
 
-(defn get-migration-dir [config]
-  ;; TODO - find a better home for me.
-  (get config :migration-dir "migrations"))
-
 (defn parse-migration-id [id]
   (try
     (Long/parseLong id)
@@ -121,18 +117,20 @@
 
 (defn list-migrations [config]
   (doall
-   (for [[id mig] (find-migrations (get-migration-dir config)
+   (for [[id mig] (find-migrations (utils/get-migration-dir config)
                                    (utils/get-exclude-scripts config))]
      (make-migration config id mig))))
 
 (defn create [config name migration-type]
-  (let [migration-dir (find-or-create-migration-dir (get-migration-dir config))
+  (let [migration-dir (find-or-create-migration-dir
+                       (utils/get-migration-dir config))
         migration-name (->kebab-case (str (timestamp) name))]
     (doseq [mig-file (proto/migration-files* migration-type migration-name)]
       (.createNewFile (io/file migration-dir mig-file)))))
 
 (defn destroy [config name]
-  (let [migration-dir (utils/find-migration-dir (get-migration-dir config))
+  (let [migration-dir (utils/find-migration-dir
+                       (utils/get-migration-dir config))
         migration-name (->kebab-case name)
         pattern (re-pattern (str "[\\d]*-" migration-name "\\..*"))
         migrations (file-seq migration-dir)]

--- a/src/migratus/migrations.clj
+++ b/src/migratus/migrations.clj
@@ -2,6 +2,7 @@
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
+            migratus.migration.edn
             migratus.migration.sql
             [migratus.protocols :as proto]
             [migratus.utils :as utils])

--- a/src/migratus/migrations.clj
+++ b/src/migratus/migrations.clj
@@ -2,7 +2,8 @@
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
-            [migratus.migration.sql :as sql-mig]
+            migratus.migration.sql
+            [migratus.protocols :as proto]
             [migratus.utils :as utils])
   (:import [java.io File StringWriter]
            java.text.SimpleDateFormat
@@ -108,11 +109,7 @@
       (let [[mig-name mig'] (first mig)]
         (if (= 1 (count mig'))
           (let [[mig-type payload] (first mig')]
-            (case mig-type
-              :sql (sql-mig/->SqlMigration id mig-name
-                                           (:up payload) (:down payload))
-              (throw (Exception. (format "Unknown type '%s' for migration %d"
-                                         (name mig-type) id)))))
+            (proto/make-migration* mig-type id mig-name payload config))
           (throw (Exception.
                   (format
                    "Multiple migration types specified for migration %d %s"

--- a/src/migratus/migrations.clj
+++ b/src/migratus/migrations.clj
@@ -1,0 +1,122 @@
+(ns migratus.migrations
+  (:require [clojure.java.io :as io]
+            [clojure.tools.logging :as log]
+            [migratus.migration.sql :as sql-mig]
+            [migratus.utils :as utils])
+  (:import [java.io File StringWriter]
+           java.text.SimpleDateFormat
+           [java.util.jar JarEntry JarFile]
+           java.util.regex.Pattern
+           java.util.Date
+           ))
+
+(defn ->kebab-case [s]
+  (-> (reduce
+        (fn [s c]
+          (if (and
+                (not-empty s)
+                (Character/isLowerCase (last s))
+                (Character/isUpperCase c))
+            (str s "-" c)
+            (str s c)))
+        "" s)
+      (clojure.string/replace #"[\s]+" "-")
+      (.replaceAll "_" "-")
+      (.toLowerCase)))
+
+(defn- timestamp []
+  (let [fmt (SimpleDateFormat. "yyyyMMddHHmmss ")]
+    (.format fmt (Date.))))
+
+(defn get-migration-dir [config]
+  ;; TODO - find a better home for me.
+  (get config :migration-dir "migrations"))
+
+(defn parse-migration-id [id]
+  (try
+    (Long/parseLong id)
+    (catch Exception e
+      (log/error e (str "failed to parse migration id: " id)))))
+
+(def default-migration-parent "resources/")
+
+(def migration-file-pattern #"^(\d+)-([^\.]+)\.(up|down)\.sql$")
+
+(defn parse-name [file-name]
+  (next (re-matches migration-file-pattern file-name)))
+
+(defn warn-on-invalid-migration [file-name]
+  (log/warn (str "skipping: '" file-name "'")
+            "migrations must match pattern:"
+            (str migration-file-pattern)))
+
+(defn find-migration-files [migration-dir exclude-scripts]
+  (->> (for [f (filter (fn [^File f] (.isFile f))
+                       (file-seq migration-dir))
+             :let [file-name (.getName ^File f)]]
+         (if-let [[id name direction] (parse-name file-name)]
+           {id {direction {:id        id
+                           :name      name
+                           :direction direction
+                           :content   (slurp f)}}}
+           (when-not (exclude-scripts (.getName f))
+             (warn-on-invalid-migration file-name))))
+       (remove nil?)))
+
+(defn find-migration-resources [dir jar init-script-name]
+  (->> (for [entry (enumeration-seq (.entries jar))
+             :when (.matches (.getName ^JarEntry entry)
+                             (str "^" (Pattern/quote dir) ".+"))
+             :let [entry-name (.replaceAll (.getName ^JarEntry entry) dir "")]]
+         (if-let [[id name direction] (parse-name entry-name)]
+           (let [w (StringWriter.)]
+             (io/copy (.getInputStream ^JarFile jar entry) w)
+             {id {direction {:id        id
+                             :name      name
+                             :direction direction
+                             :content   (.toString w)}}})
+           (when (not= entry-name init-script-name)
+             (warn-on-invalid-migration entry-name))))
+       (remove nil?)))
+
+(defn find-migrations [dir exclude-scripts]
+  (->> (let [dir (utils/ensure-trailing-slash dir)]
+         (if-let [migration-dir (utils/find-migration-dir dir)]
+           (find-migration-files migration-dir exclude-scripts)
+           (if-let [migration-jar (utils/find-migration-jar dir)]
+             (find-migration-resources dir migration-jar exclude-scripts))))
+       (apply (partial merge-with merge))))
+
+(defn find-or-create-migration-dir [dir]
+  (if-let [migration-dir (utils/find-migration-dir dir)]
+    migration-dir
+
+    ;; Couldn't find the migration dir, create it
+    (let [new-migration-dir (io/file default-migration-parent dir)]
+      (io/make-parents new-migration-dir ".")
+      new-migration-dir)))
+
+(defn list-migrations [config]
+  (for [[id mig] (find-migrations (get-migration-dir config)
+                                  (utils/get-exclude-scripts config))
+        :let [{:strs [up down]} mig]]
+    (sql-mig/->SqlMigration (parse-migration-id (or (:id up) (:id down)))
+                            (or (:name up) (:name down))
+                            (:content up)
+                            (:content down))))
+
+(defn create [config name]
+  (let [migration-dir (find-or-create-migration-dir (get-migration-dir config))
+        migration-name (->kebab-case (str (timestamp) name))
+        migration-up-name (str migration-name ".up.sql")
+        migration-down-name (str migration-name ".down.sql")]
+    (.createNewFile (File. migration-dir migration-up-name))
+    (.createNewFile (File. migration-dir migration-down-name))))
+
+(defn destroy [config name]
+  (let [migration-dir (utils/find-migration-dir (get-migration-dir config))
+        migration-name (->kebab-case name)
+        pattern (re-pattern (str "[\\d]*-" migration-name ".*.sql"))
+        migrations (file-seq migration-dir)]
+    (doseq [f (filter #(re-find pattern (.getName %)) migrations)]
+      (.delete f))))

--- a/src/migratus/protocols.clj
+++ b/src/migratus/protocols.clj
@@ -26,16 +26,10 @@
     "Initialize the data store.")
   (completed-ids [this]
     "Seq of ids of completed migrations.")
-  (migrations [this]
-    "Seq of migrations (completed or not).")
-  (create [this name]
-    "Create a new migration")
   (migrate-up [this migration]
     "Run and record an up migration")
   (migrate-down [this migration]
     "Run and record a down migration")
-  (destroy [this name]
-    "Destroy migration")
   (connect [this]
     "Opens resources necessary to run migrations against the store.")
   (disconnect [this]

--- a/src/migratus/protocols.clj
+++ b/src/migratus/protocols.clj
@@ -36,3 +36,14 @@
     "Frees resources necessary to run migrations against the store."))
 
 (defmulti make-store :store)
+
+(defmulti make-migration*
+  "Dispatcher to create migrations based on filename extension. To add support
+  for a new migration filename type, add a new defmethod for this."
+  (fn [mig-type mig-id mig-name payload config]
+    mig-type))
+
+(defmethod make-migration* :default
+  [mig-type mig-id mig-name payload config]
+  (throw (Exception. (format "Unknown type '%s' for migration %d"
+                             (clojure.core/name mig-type) mig-id))))

--- a/src/migratus/protocols.clj
+++ b/src/migratus/protocols.clj
@@ -47,3 +47,13 @@
   [mig-type mig-id mig-name payload config]
   (throw (Exception. (format "Unknown type '%s' for migration %d"
                              (clojure.core/name mig-type) mig-id))))
+
+(defmulti migration-files*
+  "Dispatcher to get a list of filenames to create when creating new migrations"
+  (fn [mig-type migration-name]
+    mig-type))
+
+(defmethod migration-files* :default
+  [mig-type migration-name]
+  (throw (Exception. (format "Unknown migration type '%s'"
+                             (clojure.core/name mig-type)))))

--- a/src/migratus/protocols.clj
+++ b/src/migratus/protocols.clj
@@ -17,8 +17,8 @@
 (defprotocol Migration
   (id [this] "Id of this migration.")
   (name [this] "Name of this migration")
-  (up [this] "Bring this migration up.")
-  (down [this] "Bring this migration down."))
+  (up [this config] "Bring this migration up.")
+  (down [this config] "Bring this migration down."))
 
 (defprotocol Store
   (config [this])
@@ -30,6 +30,10 @@
     "Seq of migrations (completed or not).")
   (create [this name]
     "Create a new migration")
+  (migrate-up [this migration]
+    "Run and record an up migration")
+  (migrate-down [this migration]
+    "Run and record a down migration")
   (destroy [this name]
     "Destroy migration")
   (connect [this]

--- a/src/migratus/utils.clj
+++ b/src/migratus/utils.clj
@@ -1,0 +1,44 @@
+(ns migratus.utils
+  (:require [clojure.java.classpath :as cp]
+            [clojure.java.io :as io])
+  (:import java.io.File
+           [java.util.jar JarEntry JarFile]
+           java.util.regex.Pattern))
+
+(def default-init-script-name "init.sql")
+
+(defn get-init-script
+  "Gets the :init-script from config, or default if missing."
+  [config]
+  (get config :init-script default-init-script-name))
+
+(defn get-exclude-scripts
+  "Returns a set of script names to exclude when finding migrations"
+  [config]
+  (into #{(get-init-script config)}
+        (get config :exclude-scripts)))
+
+(defn ensure-trailing-slash
+  "Put a trailing slash on the dirname if not present"
+  [dir]
+  (if (not= (last dir) \/)
+    (str dir "/")
+    dir))
+
+(defn find-migration-dir
+  "Finds the given directory on the classpath"
+  [dir]
+  (->> (cp/classpath-directories)
+       (map #(io/file % dir))
+       (filter #(.exists ^File %))
+       first))
+
+(defn find-migration-jar
+  "Finds the first jar on the classpath containing a directory with the given
+  name."
+  [dir]
+  (first (for [jar (cp/classpath-jarfiles)
+               :when (some #(.matches (.getName ^JarEntry %)
+                                      (str "^" (Pattern/quote dir) ".+"))
+                           (enumeration-seq (.entries ^JarFile jar)))]
+           jar)))

--- a/src/migratus/utils.clj
+++ b/src/migratus/utils.clj
@@ -42,3 +42,7 @@
                                       (str "^" (Pattern/quote dir) ".+"))
                            (enumeration-seq (.entries ^JarFile jar)))]
            jar)))
+
+(defn deep-merge
+  [& maps]
+  (apply merge-with deep-merge maps))

--- a/src/migratus/utils.clj
+++ b/src/migratus/utils.clj
@@ -5,7 +5,13 @@
            [java.util.jar JarEntry JarFile]
            java.util.regex.Pattern))
 
+(def default-migration-dir "migrations")
 (def default-init-script-name "init.sql")
+
+(defn get-migration-dir
+  "Gets the :migration-dir from config, or default if missing."
+  [config]
+  (get config :migration-dir default-migration-dir))
 
 (defn get-init-script
   "Gets the :init-script from config, or default if missing."

--- a/src/migratus/utils.clj
+++ b/src/migratus/utils.clj
@@ -44,5 +44,15 @@
            jar)))
 
 (defn deep-merge
+  "Merge keys at all nested levels of the maps."
   [& maps]
   (apply merge-with deep-merge maps))
+
+(defn recursive-delete
+  "Delete a file, including all children if it's a directory"
+  [^File f]
+  (when (.exists f)
+    (if (.isDirectory f)
+      (doseq [child (.listFiles f)]
+        (recursive-delete child))
+      (.delete f))))

--- a/test/migrations-bad-type/20170328124600-bad-type.foo
+++ b/test/migrations-bad-type/20170328124600-bad-type.foo
@@ -1,0 +1,1 @@
+-- Doesn't matter what goes in here, it won't get run.

--- a/test/migrations-duplicate-name/20170328130700-dup-name-1.up.sql
+++ b/test/migrations-duplicate-name/20170328130700-dup-name-1.up.sql
@@ -1,0 +1,1 @@
+-- Doesn't matter what goes in here, it won't get run.

--- a/test/migrations-duplicate-name/20170328130700-dup-name-2.up.sql
+++ b/test/migrations-duplicate-name/20170328130700-dup-name-2.up.sql
@@ -1,0 +1,1 @@
+-- Doesn't matter what goes in here, it won't get run.

--- a/test/migrations-duplicate-type/20170328125100-duplicate-type.edn
+++ b/test/migrations-duplicate-type/20170328125100-duplicate-type.edn
@@ -1,0 +1,1 @@
+{:namespace "doesnt.matter"}

--- a/test/migrations-duplicate-type/20170328125100-duplicate-type.up.sql
+++ b/test/migrations-duplicate-type/20170328125100-duplicate-type.up.sql
@@ -1,0 +1,1 @@
+-- Doesn't matter what goes in here, it won't get run.

--- a/test/migrations-edn/20170330142700-say-hello.edn
+++ b/test/migrations-edn/20170330142700-say-hello.edn
@@ -1,0 +1,3 @@
+{:ns migratus.test.migration.edn.test-script
+ :up-fn migrate-up
+ :down-fn migrate-down}

--- a/test/migratus/mock.clj
+++ b/test/migratus/mock.clj
@@ -20,10 +20,10 @@
     id)
   (name [this]
     name)
-  (up [this]
+  (up [this config]
     (swap! ups conj id)
     :success)
-  (down [this]
+  (down [this config]
     (swap! downs conj id)
     :success))
 
@@ -34,6 +34,10 @@
     completed-ids)
   (migrations [this]
     migrations)
+  (migrate-up [this migration]
+    (proto/up migration {}))
+  (migrate-down [this migration]
+    (proto/down migration {}))
   (connect [this])
   (disconnect [this]))
 

--- a/test/migratus/mock.clj
+++ b/test/migratus/mock.clj
@@ -27,13 +27,11 @@
     (swap! downs conj id)
     :success))
 
-(defrecord MockStore [completed-ids migrations]
+(defrecord MockStore [completed-ids]
   proto/Store
   (init [this])
   (completed-ids [this]
     completed-ids)
-  (migrations [this]
-    migrations)
   (migrate-up [this migration]
     (proto/up migration {}))
   (migrate-down [this migration]
@@ -45,5 +43,5 @@
   (MockMigration. nil id name ups downs))
 
 (defmethod proto/make-store :mock
-  [{:keys [completed-ids migrations]}]
-  (MockStore. completed-ids (map make-migration migrations)))
+  [{:keys [completed-ids]}]
+  (MockStore. completed-ids))

--- a/test/migratus/mock.clj
+++ b/test/migratus/mock.clj
@@ -27,15 +27,18 @@
     (swap! downs conj id)
     :success))
 
-(defrecord MockStore [completed-ids]
+(defrecord MockStore [completed-ids config]
   proto/Store
   (init [this])
   (completed-ids [this]
-    completed-ids)
+    @completed-ids)
   (migrate-up [this migration]
-    (proto/up migration {}))
+    (proto/up migration config)
+    (swap! completed-ids conj (proto/id migration))
+    :success)
   (migrate-down [this migration]
-    (proto/down migration {}))
+    (proto/down migration config)
+    (swap! completed-ids disj (proto/id migration)))
   (connect [this])
   (disconnect [this]))
 
@@ -43,5 +46,5 @@
   (MockMigration. nil id name ups downs))
 
 (defmethod proto/make-store :mock
-  [{:keys [completed-ids]}]
-  (MockStore. completed-ids))
+  [{:keys [completed-ids] :as config}]
+  (MockStore. completed-ids config))

--- a/test/migratus/test/core.clj
+++ b/test/migratus/test/core.clj
@@ -31,7 +31,7 @@
   (let [ups (atom [])
         downs (atom [])
         config {:store :mock
-                :completed-ids [1 3]}]
+                :completed-ids (atom #{1 3})}]
     (with-redefs [mig/list-migrations (constantly (migrations ups downs))]
       (migrate config))
     (is (= [2 4] @ups))
@@ -41,7 +41,7 @@
   (let [ups (atom [])
         downs (atom [])
         config {:store :mock
-                :completed-ids [1 3]}]
+                :completed-ids (atom #{1 3})}]
     (with-redefs [mig/list-migrations (constantly (migrations ups downs))]
       (testing "should bring up an uncompleted migration"
         (up config 4 2)
@@ -58,7 +58,7 @@
   (let [ups (atom [])
         downs (atom [])
         config {:store :mock
-                :completed-ids [1 3]}]
+                :completed-ids (atom #{1 3})}]
     (with-redefs [mig/list-migrations (constantly (migrations ups downs))]
       (testing "should bring down a completed migration"
         (down config 1 3)
@@ -125,7 +125,7 @@
   (let [ups (atom [])
         downs (atom [])
         config {:store :mock
-                :completed-ids [1]}]
+                :completed-ids (atom #{1})}]
     (with-redefs [mig/list-migrations (constantly (migrations ups downs))]
       (testing "should return the list of pending migrations"
         (is (= "You have 3 pending migrations:\nid-2\nid-3\nid-4"

--- a/test/migratus/test/core.clj
+++ b/test/migratus/test/core.clj
@@ -16,8 +16,9 @@
             [migratus.mock :as mock]
             [clojure.test :refer :all]
             [migratus.core :refer :all]
-            migratus.database
             migratus.logger
+            [migratus.migrations :as mig]
+            [migratus.utils :as utils]
             [clojure.java.io :as io])
   (:import [migratus.mock MockStore MockMigration]))
 
@@ -31,7 +32,7 @@
         downs (atom [])
         config {:store :mock
                 :completed-ids [1 3]}]
-    (with-redefs [migratus.database/list-migrations (constantly (migrations ups downs))]
+    (with-redefs [mig/list-migrations (constantly (migrations ups downs))]
       (migrate config))
     (is (= [2 4] @ups))
     (is (empty? @downs))))
@@ -41,7 +42,7 @@
         downs (atom [])
         config {:store :mock
                 :completed-ids [1 3]}]
-    (with-redefs [migratus.database/list-migrations (constantly (migrations ups downs))]
+    (with-redefs [mig/list-migrations (constantly (migrations ups downs))]
       (testing "should bring up an uncompleted migration"
         (up config 4 2)
         (is (= [2 4] @ups))
@@ -58,7 +59,7 @@
         downs (atom [])
         config {:store :mock
                 :completed-ids [1 3]}]
-    (with-redefs [migratus.database/list-migrations (constantly (migrations ups downs))]
+    (with-redefs [mig/list-migrations (constantly (migrations ups downs))]
       (testing "should bring down a completed migration"
         (down config 1 3)
         (is (empty? @ups))
@@ -71,7 +72,7 @@
         (is (empty? @downs))))))
 
 (defn- migration-exists? [name]
-    (let [migrations (file-seq (migratus.database/find-migration-dir "migrations"))
+    (let [migrations (file-seq (utils/find-migration-dir "migrations"))
           names (map #(.getName %) migrations)]
         (filter #(.contains % name) names)))
 
@@ -101,9 +102,9 @@
       (io/delete-file (io/file "resources" migration-dir)))
 
     (testing "when migration dir doesn't exist, it is created"
-      (is (nil? (migratus.database/find-migration-dir migration-dir)))
+      (is (nil? (utils/find-migration-dir migration-dir)))
       (create config migration)
-      (is (not (nil? (migratus.database/find-migration-dir migration-dir))))
+      (is (not (nil? (utils/find-migration-dir migration-dir))))
       (is (migration-exists? migration-up))
       (is (migration-exists? migration-down)))
 
@@ -117,7 +118,7 @@
         downs (atom [])
         config {:store :mock
                 :completed-ids [1]}]
-    (with-redefs [migratus.database/list-migrations (constantly (migrations ups downs))]
+    (with-redefs [mig/list-migrations (constantly (migrations ups downs))]
       (testing "should return the list of pending migrations"
         (is (= "You have 3 pending migrations:\nid-2\nid-3\nid-4"
                (migratus.core/pending-list config)))))))

--- a/test/migratus/test/database.clj
+++ b/test/migratus/test/database.clj
@@ -20,34 +20,13 @@
             [migratus.database :refer :all]
             migratus.logger
             [migratus.test.migration.edn :as test-edn]
+            [migratus.test.migration.sql :as test-sql]
             [migratus.utils :as utils])
   (:import java.io.File))
 
-(def db-store (str (.getName (io/file ".")) "/site.db"))
-
-(def config {:store                :database
-             :migration-dir        "migrations/"
-             :migration-table-name "foo_bar"
-             :db                   {:classname   "org.h2.Driver"
-                                    :subprotocol "h2"
-                                    :subname     db-store}})
-
-(defn reset-db []
-  (letfn [(delete [f]
-            (when (.exists f)
-              (.delete f)))]
-    (delete (io/file "site.db.trace.db"))
-    (delete (io/file "site.db.mv.db"))))
-
-(defn setup-test-db [f]
-  (reset-db)
-  (f))
-
-(defn verify-table-exists? [config table-name]
-  (let [db (connect* (:db config))
-        result (table-exists? db table-name)]
-    (.close (:connection db))
-    result))
+(def config (merge test-sql/test-config
+                   {:store :database
+                    :migration-table-name "foo_bar"}))
 
 (defn test-with-store [store & commands]
   (try
@@ -57,60 +36,60 @@
     (finally
       (proto/disconnect store))))
 
-(use-fixtures :each setup-test-db)
+(use-fixtures :each test-sql/setup-test-db)
 
 (deftest test-make-store
   (testing "should create default table name"
-    (is (not (verify-table-exists?
+    (is (not (test-sql/verify-table-exists?
                (dissoc config :migration-table-name) default-migrations-table)))
     (test-with-store
       (proto/make-store (dissoc config :migration-table-name))
       (fn [config]
-        (is (verify-table-exists? config default-migrations-table)))))
-  (reset-db)
+        (is (test-sql/verify-table-exists? config default-migrations-table)))))
+  (test-sql/reset-db)
   (testing "should create schema_migrations table"
-    (is (not (verify-table-exists? config "foo_bar")))
+    (is (not (test-sql/verify-table-exists? config "foo_bar")))
     (test-with-store
       (proto/make-store config)
       (fn [config]
-        (is (verify-table-exists? config "foo_bar"))))))
+        (is (test-sql/verify-table-exists? config "foo_bar"))))))
 
 (deftest test-init
   (testing "db init"
-    (reset-db)
+    (test-sql/reset-db)
     (let [store (proto/make-store config)]
       (proto/init store))))
 
 (deftest test-migrate
-  (is (not (verify-table-exists? config "foo")))
-  (is (not (verify-table-exists? config "bar")))
-  (is (not (verify-table-exists? config "quux")))
-  (is (not (verify-table-exists? config "quux2")))
+  (is (not (test-sql/verify-table-exists? config "foo")))
+  (is (not (test-sql/verify-table-exists? config "bar")))
+  (is (not (test-sql/verify-table-exists? config "quux")))
+  (is (not (test-sql/verify-table-exists? config "quux2")))
   (core/migrate config)
-  (is (verify-table-exists? config "foo"))
-  (is (verify-table-exists? config "bar"))
-  (is (verify-table-exists? config "quux"))
-  (is (verify-table-exists? config "quux2"))
+  (is (test-sql/verify-table-exists? config "foo"))
+  (is (test-sql/verify-table-exists? config "bar"))
+  (is (test-sql/verify-table-exists? config "quux"))
+  (is (test-sql/verify-table-exists? config "quux2"))
   (core/down config 20111202110600)
-  (is (not (verify-table-exists? config "foo")))
-  (is (verify-table-exists? config "bar"))
-  (is (verify-table-exists? config "quux"))
-  (is (verify-table-exists? config "quux2"))
+  (is (not (test-sql/verify-table-exists? config "foo")))
+  (is (test-sql/verify-table-exists? config "bar"))
+  (is (test-sql/verify-table-exists? config "quux"))
+  (is (test-sql/verify-table-exists? config "quux2"))
   (core/migrate config)
-  (is (verify-table-exists? config "foo"))
-  (is (verify-table-exists? config "bar"))
-  (is (verify-table-exists? config "quux"))
-  (is (verify-table-exists? config "quux2"))
+  (is (test-sql/verify-table-exists? config "foo"))
+  (is (test-sql/verify-table-exists? config "bar"))
+  (is (test-sql/verify-table-exists? config "quux"))
+  (is (test-sql/verify-table-exists? config "quux2"))
   (core/down config 20111202110600 20120827170200)
-  (is (not (verify-table-exists? config "foo")))
-  (is (verify-table-exists? config "bar"))
-  (is (not (verify-table-exists? config "quux")))
-  (is (not (verify-table-exists? config "quux2")))
+  (is (not (test-sql/verify-table-exists? config "foo")))
+  (is (test-sql/verify-table-exists? config "bar"))
+  (is (not (test-sql/verify-table-exists? config "quux")))
+  (is (not (test-sql/verify-table-exists? config "quux2")))
   (core/up config 20111202110600 20120827170200)
-  (is (verify-table-exists? config "foo"))
-  (is (verify-table-exists? config "bar"))
-  (is (verify-table-exists? config "quux"))
-  (is (verify-table-exists? config "quux2")))
+  (is (test-sql/verify-table-exists? config "foo"))
+  (is (test-sql/verify-table-exists? config "bar"))
+  (is (test-sql/verify-table-exists? config "quux"))
+  (is (test-sql/verify-table-exists? config "quux2")))
 
 (defn comment-out-bar-statements [sql]
   (if (re-find #"CREATE TABLE IF NOT EXISTS bar" sql)
@@ -118,15 +97,15 @@
     sql))
 
 (deftest test-migrate-with-modify-sql-fn
-  (is (not (verify-table-exists? config "foo")))
-  (is (not (verify-table-exists? config "bar")))
-  (is (not (verify-table-exists? config "quux")))
-  (is (not (verify-table-exists? config "quux2")))
+  (is (not (test-sql/verify-table-exists? config "foo")))
+  (is (not (test-sql/verify-table-exists? config "bar")))
+  (is (not (test-sql/verify-table-exists? config "quux")))
+  (is (not (test-sql/verify-table-exists? config "quux2")))
   (core/migrate (assoc config :modify-sql-fn comment-out-bar-statements))
-  (is (verify-table-exists? config "foo"))
-  (is (not (verify-table-exists? config "bar")))
-  (is (verify-table-exists? config "quux"))
-  (is (verify-table-exists? config "quux2")))
+  (is (test-sql/verify-table-exists? config "foo"))
+  (is (not (test-sql/verify-table-exists? config "bar")))
+  (is (test-sql/verify-table-exists? config "quux"))
+  (is (test-sql/verify-table-exists? config "quux2")))
 
 (deftest test-migration-table-creation-is-hooked
   (let [hook-called (atom false)]
@@ -140,20 +119,20 @@
     (is @hook-called)))
 
 (deftest test-migrate-until-just-before
-  (is (not (verify-table-exists? config "foo")))
-  (is (not (verify-table-exists? config "bar")))
-  (is (not (verify-table-exists? config "quux")))
-  (is (not (verify-table-exists? config "quux2")))
+  (is (not (test-sql/verify-table-exists? config "foo")))
+  (is (not (test-sql/verify-table-exists? config "bar")))
+  (is (not (test-sql/verify-table-exists? config "quux")))
+  (is (not (test-sql/verify-table-exists? config "quux2")))
   (core/migrate-until-just-before config 20120827170200)
-  (is (verify-table-exists? config "foo"))
-  (is (verify-table-exists? config "bar"))
-  (is (not (verify-table-exists? config "quux")))
-  (is (not (verify-table-exists? config "quux2")))
+  (is (test-sql/verify-table-exists? config "foo"))
+  (is (test-sql/verify-table-exists? config "bar"))
+  (is (not (test-sql/verify-table-exists? config "quux")))
+  (is (not (test-sql/verify-table-exists? config "quux2")))
   (core/migrate config)
-  (is (verify-table-exists? config "foo"))
-  (is (verify-table-exists? config "bar"))
-  (is (verify-table-exists? config "quux"))
-  (is (verify-table-exists? config "quux2")))
+  (is (test-sql/verify-table-exists? config "foo"))
+  (is (test-sql/verify-table-exists? config "bar"))
+  (is (test-sql/verify-table-exists? config "quux"))
+  (is (test-sql/verify-table-exists? config "quux2")))
 
 (deftest test-migration-ignored-when-already-reserved
   (test-with-store
@@ -163,21 +142,21 @@
        (is (mark-reserved db migration-table-name))
        (is (not (mark-reserved db migration-table-name))))
      (testing "migrations don't run when locked"
-       (is (not (verify-table-exists? config "foo")))
+       (is (not (test-sql/verify-table-exists? config "foo")))
        (core/migrate config)
-       (is (not (verify-table-exists? config "foo"))))
+       (is (not (test-sql/verify-table-exists? config "foo"))))
      (testing "migrations run once lock is freed"
        (mark-unreserved db migration-table-name)
        (core/migrate config)
-       (is (verify-table-exists? config "foo")))
+       (is (test-sql/verify-table-exists? config "foo")))
      (testing "rollback migration isn't run when locked"
        (is (mark-reserved db migration-table-name))
        (core/down config 20111202110600)
-       (is (verify-table-exists? config "foo")))
+       (is (test-sql/verify-table-exists? config "foo")))
      (testing "rollback migration run once lock is freed"
        (mark-unreserved db migration-table-name)
        (core/down config 20111202110600)
-       (is (not (verify-table-exists? config "foo")))))))
+       (is (not (test-sql/verify-table-exists? config "foo")))))))
 
 (defn copy-dir
   [^File from ^File to]
@@ -198,18 +177,18 @@
       (copy-dir (io/file "test/migrations") migrations-dir)
       (copy-dir (io/file "test/migrations-edn") migrations-dir)
 
-      (is (not (verify-table-exists? test-config "foo")))
-      (is (not (verify-table-exists? test-config "bar")))
-      (is (not (verify-table-exists? test-config "quux")))
-      (is (not (verify-table-exists? test-config "quux2")))
+      (is (not (test-sql/verify-table-exists? test-config "foo")))
+      (is (not (test-sql/verify-table-exists? test-config "bar")))
+      (is (not (test-sql/verify-table-exists? test-config "quux")))
+      (is (not (test-sql/verify-table-exists? test-config "quux2")))
       (is (not (test-edn/test-file-exists?)))
 
       (core/migrate test-config)
 
-      (is (verify-table-exists? test-config "foo"))
-      (is (verify-table-exists? test-config "bar"))
-      (is (verify-table-exists? test-config "quux"))
-      (is (verify-table-exists? test-config "quux2"))
+      (is (test-sql/verify-table-exists? test-config "foo"))
+      (is (test-sql/verify-table-exists? test-config "bar"))
+      (is (test-sql/verify-table-exists? test-config "quux"))
+      (is (test-sql/verify-table-exists? test-config "quux2"))
       (is (test-edn/test-file-exists?))
 
       (finally

--- a/test/migratus/test/database.clj
+++ b/test/migratus/test/database.clj
@@ -78,61 +78,6 @@
     (let [store (proto/make-store config)]
       (proto/init store))))
 
-(deftest test-parse-name
-  (is (= ["20111202110600" "create-foo-table" "up"]
-         (parse-name "20111202110600-create-foo-table.up.sql")))
-  (is (= ["20111202110600" "create-foo-table" "down"]
-         (parse-name "20111202110600-create-foo-table.down.sql"))))
-
-(deftest test-find-migrations
-  (is (= {"20111202113000"
-          {"down" {:id        "20111202113000"
-                   :name      "create-bar-table"
-                   :direction "down"
-                   :content   "DROP TABLE IF EXISTS bar;\n"}
-           "up"   {:id        "20111202113000"
-                   :name      "create-bar-table"
-                   :direction "up"
-                   :content   "CREATE TABLE IF NOT EXISTS bar(id BIGINT);\n"}}
-          "20111202110600"
-          {"up"   {:id        "20111202110600"
-                   :name      "create-foo-table"
-                   :direction "up"
-                   :content   "CREATE TABLE IF NOT EXISTS foo(id bigint);\n"}
-           "down" {:id        "20111202110600"
-                   :name      "create-foo-table"
-                   :direction "down"
-                   :content   "DROP TABLE IF EXISTS foo;\n"}}
-          "20120827170200"
-          {"up"   {:id        "20120827170200"
-                   :name      "multiple-statements"
-                   :direction "up"
-                   :content   (str "-- this is the first statement\n\n"
-                                   "CREATE TABLE\nquux\n"
-                                   "(id bigint,\n"
-                                   " name varchar(255));\n\n"
-                                   "--;;\n"
-                                   "-- comment for the second statement\n\n"
-                                   "CREATE TABLE quux2(id bigint, name varchar(255));\n")}
-           "down" {:id        "20120827170200"
-                   :name      "multiple-statements"
-                   :direction "down"
-                   :content   (str "DROP TABLE quux2;\n"
-                                   "--;;\n"
-                                   "DROP TABLE quux;\n")}}}
-         (find-migrations "migrations"))))
-
-(deftest test-find-jar-migrations
-  (is (= {"20111214173500"
-          {"down" {:id        "20111214173500"
-                   :name      "create-baz-table"
-                   :direction "down", :content "DROP TABLE IF EXISTS baz;\n"}
-           "up"   {:id        "20111214173500"
-                   :name      "create-baz-table"
-                   :direction "up"
-                   :content   "CREATE TABLE IF NOT EXISTS baz(id bigint);\n"}}}
-         (find-migrations "jar-migrations"))))
-
 (deftest test-migrate
   (is (not (verify-table-exists? config "foo")))
   (is (not (verify-table-exists? config "bar")))

--- a/test/migratus/test/migration/edn.clj
+++ b/test/migratus/test/migration/edn.clj
@@ -1,0 +1,104 @@
+(ns migratus.test.migration.edn
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer :all]
+            [migratus.migration.edn :refer :all]
+            [migratus.protocols :as proto])
+  (:import java.io.File))
+
+(defn recursive-delete [^File f]
+  (when (.exists f)
+    (if (.isDirectory f)
+      (doseq [child (.listFiles f)]
+        (recursive-delete child))
+      (.delete f))))
+
+(defn unload [ns-sym]
+  (remove-ns ns-sym)
+  (dosync
+   (commute (deref #'clojure.core/*loaded-libs*) disj ns-sym)))
+
+(def test-namespace 'migratus.test.migration.edn.test-script)
+(def test-dir "target/edn-test")
+(def test-config {:output-dir test-dir})
+
+(defn test-file-exists? []
+  (let [f (io/file test-dir "hello.txt")]
+    (and (.exists f)
+         (= "Hello, world!" (slurp f)))))
+
+(use-fixtures :each
+  (fn [f]
+    (unload test-namespace)
+    (recursive-delete (io/file test-dir))
+    (f)))
+
+(deftest test-to-sym
+  (are [x y] (= y (to-sym x))
+    nil nil
+    "aaa" 'aaa
+    'aaa 'aaa
+    :aaa 'aaa)
+  (are [x] (thrown-with-msg?
+            IllegalArgumentException
+            #"Namespaced symbol not allowed"
+            (to-sym x))
+    "aaa/bbb"
+    'aaa/bbb
+    :aaa/bbb
+    'a.b.c/def
+    :a.b.c/def))
+
+(deftest test-resolve-fn
+  (require test-namespace)
+  (is (var? (resolve-fn "test-mig" test-namespace "migrate-up")))
+  (is (var? (resolve-fn "test-mig" test-namespace 'migrate-up)))
+  (is (var? (resolve-fn "test-mig" test-namespace :migrate-up)))
+  (is (thrown-with-msg?
+       IllegalArgumentException
+       #"Unable to resolve"
+       (resolve-fn "test-mig" test-namespace "not-a-fn")))
+  (is (thrown-with-msg?
+       IllegalArgumentException
+       #"Namespaced symbol not allowed"
+       (resolve-fn "test-mig" test-namespace "clojure.core/map"))))
+
+(defn edn-mig [content]
+  (proto/make-migration* :edn 1 "edn-migration" (pr-str content) nil))
+
+(deftest test-invalid-migration
+  (testing "namespace is required"
+    (is (thrown-with-msg?
+         IllegalArgumentException
+         #"Invalid migration .* no namespace"
+         (edn-mig {}))))
+  (testing "namespace must exist"
+    (is (thrown?
+         Exception
+         (edn-mig {:ns 'foo.bar.baz}))))
+  (testing "fn must exist"
+    (is (thrown-with-msg?
+         IllegalArgumentException
+         #"Unable to resolve"
+         (edn-mig {:ns test-namespace
+                   :up-fn 'not-a-real-fn
+                   :down-fn 'not-a-real-fn})))))
+
+(deftest test-edn-migration
+  (let [mig (edn-mig {:ns test-namespace
+                      :up-fn 'migrate-up
+                      :down-fn 'migrate-down})]
+    (is (not (test-file-exists?)))
+    (proto/up mig test-config)
+    (is (test-file-exists?))
+    (proto/down mig test-config)
+    (is (not (test-file-exists?)))))
+
+(deftest test-edn-down-optional
+  (let [mig (edn-mig {:ns test-namespace
+                      :up-fn 'migrate-up
+                      :down-fn nil})]
+    (is (not (test-file-exists?)))
+    (proto/up mig test-config)
+    (is (test-file-exists?))
+    (proto/down mig test-config)
+    (is (test-file-exists?))))

--- a/test/migratus/test/migration/edn.clj
+++ b/test/migratus/test/migration/edn.clj
@@ -1,7 +1,9 @@
 (ns migratus.test.migration.edn
   (:require [clojure.java.io :as io]
             [clojure.test :refer :all]
+            [migratus.core :as core]
             [migratus.migration.edn :refer :all]
+            migratus.mock
             [migratus.protocols :as proto])
   (:import java.io.File))
 
@@ -111,3 +113,14 @@
     (is (test-file-exists?))
     (proto/down mig test-config)
     (is (test-file-exists?))))
+
+(deftest test-run-edn-migrations
+  (let [config (merge test-config
+                      {:store :mock
+                       :completed-ids (atom #{})
+                       :migration-dir "migrations-edn"})]
+    (is (not (test-file-exists?)))
+    (core/migrate config)
+    (is (test-file-exists?))
+    (core/rollback config)
+    (is (not (test-file-exists?)))))

--- a/test/migratus/test/migration/edn.clj
+++ b/test/migratus/test/migration/edn.clj
@@ -26,8 +26,17 @@
     (and (.exists f)
          (= "Hello, world!" (slurp f)))))
 
+(use-fixtures :once
+  (fn [f]
+    (f)
+    ;; `lein test` thinks it needs to test this namespace, so make sure
+    ;; that it exists when we're done
+    (require test-namespace)))
+
 (use-fixtures :each
   (fn [f]
+    ;; unload the namespace before each test to ensure that it's loaded
+    ;; appropriately by the edn-migration code.
     (unload test-namespace)
     (recursive-delete (io/file test-dir))
     (f)))

--- a/test/migratus/test/migration/edn.clj
+++ b/test/migratus/test/migration/edn.clj
@@ -4,15 +4,9 @@
             [migratus.core :as core]
             [migratus.migration.edn :refer :all]
             migratus.mock
-            [migratus.protocols :as proto])
+            [migratus.protocols :as proto]
+            [migratus.utils :as utils])
   (:import java.io.File))
-
-(defn recursive-delete [^File f]
-  (when (.exists f)
-    (if (.isDirectory f)
-      (doseq [child (.listFiles f)]
-        (recursive-delete child))
-      (.delete f))))
 
 (defn unload [ns-sym]
   (remove-ns ns-sym)
@@ -40,7 +34,7 @@
     ;; unload the namespace before each test to ensure that it's loaded
     ;; appropriately by the edn-migration code.
     (unload test-namespace)
-    (recursive-delete (io/file test-dir))
+    (utils/recursive-delete (io/file test-dir))
     (f)))
 
 (deftest test-to-sym

--- a/test/migratus/test/migration/edn/test_script.clj
+++ b/test/migratus/test/migration/edn/test_script.clj
@@ -1,0 +1,13 @@
+(ns migratus.test.migration.edn.test-script
+  (:require [clojure.java.io :as io]))
+
+(def test-file-name "hello.txt")
+
+(defn migrate-up [{:keys [output-dir]}]
+  (.mkdirs (io/file output-dir))
+  (spit (io/file output-dir test-file-name) "Hello, world!"))
+
+(defn migrate-down [config]
+  (let [f (io/file (:output-dir config) test-file-name)]
+    (when (.exists f)
+      (.delete f))))

--- a/test/migratus/test/migration/sql.clj
+++ b/test/migratus/test/migration/sql.clj
@@ -1,0 +1,57 @@
+(ns migratus.test.migration.sql
+  (:require [clojure.java.io :as io]
+            [clojure.java.jdbc :as sql]
+            [clojure.test :refer :all]
+            [migratus.core :as core]
+            [migratus.database :as db]
+            [migratus.migration.sql :refer :all]
+            migratus.mock
+            [migratus.protocols :as proto]))
+
+(def db-store (str (.getName (io/file ".")) "/site.db"))
+
+(def test-config {:migration-dir        "migrations/"
+                  :db                   {:classname   "org.h2.Driver"
+                                         :subprotocol "h2"
+                                         :subname     db-store}})
+
+(defn reset-db []
+  (letfn [(delete [f]
+            (when (.exists f)
+              (.delete f)))]
+    (delete (io/file "site.db.trace.db"))
+    (delete (io/file "site.db.mv.db"))))
+
+(defn setup-test-db [f]
+  (reset-db)
+  (f))
+
+(use-fixtures :each setup-test-db)
+
+(defn verify-table-exists? [config table-name]
+  (sql/with-db-connection [db (:db config)]
+    (db/table-exists? db table-name)))
+
+(deftest test-run-sql-migrations
+  (let [config (merge test-config
+                      {:store :mock
+                       :completed-ids (atom #{})})]
+
+    (is (not (verify-table-exists? config "foo")))
+    (is (not (verify-table-exists? config "bar")))
+    (is (not (verify-table-exists? config "quux")))
+    (is (not (verify-table-exists? config "quux2")))
+    
+    (core/migrate config)
+    
+    (is (verify-table-exists? config "foo"))
+    (is (verify-table-exists? config "bar"))
+    (is (verify-table-exists? config "quux"))
+    (is (verify-table-exists? config "quux2"))
+    
+    (core/rollback config)
+    
+    (is (verify-table-exists? config "foo"))
+    (is (verify-table-exists? config "bar"))
+    (is (not (verify-table-exists? config "quux")))
+    (is (not (verify-table-exists? config "quux2")))))

--- a/test/migratus/test/migrations.clj
+++ b/test/migratus/test/migrations.clj
@@ -23,40 +23,28 @@
 
 (deftest test-find-migrations
   (is (= {"20111202113000"
-          {:sql
-           {:up   {:id        "20111202113000"
-                   :name      "create-bar-table"
-                   :content   "CREATE TABLE IF NOT EXISTS bar(id BIGINT);\n"}
-            :down {:id        "20111202113000"
-                   :name      "create-bar-table"
-                   :content   "DROP TABLE IF EXISTS bar;\n"}}}
+          {"create-bar-table"
+           {:sql
+            {:up   "CREATE TABLE IF NOT EXISTS bar(id BIGINT);\n"
+             :down "DROP TABLE IF EXISTS bar;\n"}}}
           "20111202110600"
-          {:sql
-           {:up   {:id        "20111202110600"
-                   :name      "create-foo-table"
-                   :content   "CREATE TABLE IF NOT EXISTS foo(id bigint);\n"}
-            :down {:id        "20111202110600"
-                   :name      "create-foo-table"
-                   :content   "DROP TABLE IF EXISTS foo;\n"}}}
+          {"create-foo-table"
+           {:sql
+            {:up   "CREATE TABLE IF NOT EXISTS foo(id bigint);\n"
+             :down "DROP TABLE IF EXISTS foo;\n"}}}
           "20120827170200"
-          {:sql
-           {:up   {:id        "20120827170200"
-                   :name      "multiple-statements"
-                   :content   multi-stmt-up}
-            :down {:id        "20120827170200"
-                   :name      "multiple-statements"
-                   :content   multi-stmt-down}}}}
+          {"multiple-statements"
+           {:sql
+            {:up   multi-stmt-up
+             :down multi-stmt-down}}}}
          (find-migrations "migrations" #{"init.sql"}))))
 
 (deftest test-find-jar-migrations
   (is (= {"20111214173500"
-          {:sql
-           {:up   {:id        "20111214173500"
-                   :name      "create-baz-table"
-                   :content   "CREATE TABLE IF NOT EXISTS baz(id bigint);\n"}
-            :down {:id        "20111214173500"
-                   :name      "create-baz-table"
-                   :content "DROP TABLE IF EXISTS baz;\n"}}}}
+          {"create-baz-table"
+           {:sql
+            {:up   "CREATE TABLE IF NOT EXISTS baz(id bigint);\n"
+             :down "DROP TABLE IF EXISTS baz;\n"}}}}
          (find-migrations "jar-migrations" #{"init.sql"}))))
 
 (deftest test-list-migrations
@@ -90,4 +78,7 @@
        (list-migrations {:migration-dir "migrations-duplicate-type"}))))
 
 (deftest test-list-migrations-duplicate-name
-  (is false "implement me"))
+  (is (thrown-with-msg?
+       Exception
+       #"Multiple migrations with id"
+       (list-migrations {:migration-dir "migrations-duplicate-name"}))))

--- a/test/migratus/test/migrations.clj
+++ b/test/migratus/test/migrations.clj
@@ -1,58 +1,93 @@
 (ns migratus.test.migrations
   (:require [clojure.test :refer :all]
+            [migratus.migration.sql :as sql-mig]
             [migratus.migrations :refer :all]))
 
 (deftest test-parse-name
-  (is (= ["20111202110600" "create-foo-table" "up"]
+  (is (= ["20111202110600" "create-foo-table" ["up" "sql"]]
          (parse-name "20111202110600-create-foo-table.up.sql")))
-  (is (= ["20111202110600" "create-foo-table" "down"]
+  (is (= ["20111202110600" "create-foo-table" ["down" "sql"]]
          (parse-name "20111202110600-create-foo-table.down.sql"))))
+
+(def multi-stmt-up (str "-- this is the first statement\n\n"
+                        "CREATE TABLE\nquux\n"
+                        "(id bigint,\n"
+                        " name varchar(255));\n\n"
+                        "--;;\n"
+                        "-- comment for the second statement\n\n"
+                        "CREATE TABLE quux2(id bigint, name varchar(255));\n"))
+
+(def multi-stmt-down (str "DROP TABLE quux2;\n"
+                          "--;;\n"
+                          "DROP TABLE quux;\n"))
 
 (deftest test-find-migrations
   (is (= {"20111202113000"
-          {"down" {:id        "20111202113000"
+          {:sql
+           {:up   {:id        "20111202113000"
                    :name      "create-bar-table"
-                   :direction "down"
-                   :content   "DROP TABLE IF EXISTS bar;\n"}
-           "up"   {:id        "20111202113000"
+                   :content   "CREATE TABLE IF NOT EXISTS bar(id BIGINT);\n"}
+            :down {:id        "20111202113000"
                    :name      "create-bar-table"
-                   :direction "up"
-                   :content   "CREATE TABLE IF NOT EXISTS bar(id BIGINT);\n"}}
+                   :content   "DROP TABLE IF EXISTS bar;\n"}}}
           "20111202110600"
-          {"up"   {:id        "20111202110600"
+          {:sql
+           {:up   {:id        "20111202110600"
                    :name      "create-foo-table"
-                   :direction "up"
                    :content   "CREATE TABLE IF NOT EXISTS foo(id bigint);\n"}
-           "down" {:id        "20111202110600"
+            :down {:id        "20111202110600"
                    :name      "create-foo-table"
-                   :direction "down"
-                   :content   "DROP TABLE IF EXISTS foo;\n"}}
+                   :content   "DROP TABLE IF EXISTS foo;\n"}}}
           "20120827170200"
-          {"up"   {:id        "20120827170200"
+          {:sql
+           {:up   {:id        "20120827170200"
                    :name      "multiple-statements"
-                   :direction "up"
-                   :content   (str "-- this is the first statement\n\n"
-                                   "CREATE TABLE\nquux\n"
-                                   "(id bigint,\n"
-                                   " name varchar(255));\n\n"
-                                   "--;;\n"
-                                   "-- comment for the second statement\n\n"
-                                   "CREATE TABLE quux2(id bigint, name varchar(255));\n")}
-           "down" {:id        "20120827170200"
+                   :content   multi-stmt-up}
+            :down {:id        "20120827170200"
                    :name      "multiple-statements"
-                   :direction "down"
-                   :content   (str "DROP TABLE quux2;\n"
-                                   "--;;\n"
-                                   "DROP TABLE quux;\n")}}}
+                   :content   multi-stmt-down}}}}
          (find-migrations "migrations" #{"init.sql"}))))
 
 (deftest test-find-jar-migrations
   (is (= {"20111214173500"
-          {"down" {:id        "20111214173500"
+          {:sql
+           {:up   {:id        "20111214173500"
                    :name      "create-baz-table"
-                   :direction "down", :content "DROP TABLE IF EXISTS baz;\n"}
-           "up"   {:id        "20111214173500"
+                   :content   "CREATE TABLE IF NOT EXISTS baz(id bigint);\n"}
+            :down {:id        "20111214173500"
                    :name      "create-baz-table"
-                   :direction "up"
-                   :content   "CREATE TABLE IF NOT EXISTS baz(id bigint);\n"}}}
+                   :content "DROP TABLE IF EXISTS baz;\n"}}}}
          (find-migrations "jar-migrations" #{"init.sql"}))))
+
+(deftest test-list-migrations
+  (is (= #{(sql-mig/->SqlMigration
+            20111202113000
+            "create-bar-table"
+            "CREATE TABLE IF NOT EXISTS bar(id BIGINT);\n"
+            "DROP TABLE IF EXISTS bar;\n")
+           (sql-mig/->SqlMigration
+            20111202110600
+            "create-foo-table"
+            "CREATE TABLE IF NOT EXISTS foo(id bigint);\n"
+            "DROP TABLE IF EXISTS foo;\n")
+           (sql-mig/->SqlMigration
+            20120827170200
+            "multiple-statements"
+            multi-stmt-up
+            multi-stmt-down)}
+         (set (list-migrations {:migration-dir "migrations"})))))
+
+(deftest test-list-migrations-bad-type
+  (is (thrown-with-msg?
+       Exception
+       #"Unknown type 'foo' for migration"
+       (list-migrations {:migration-dir "migrations-bad-type"}))))
+
+(deftest test-list-migrations-duplicate-type
+  (is (thrown-with-msg?
+       Exception
+       #"Multiple migration types"
+       (list-migrations {:migration-dir "migrations-duplicate-type"}))))
+
+(deftest test-list-migrations-duplicate-name
+  (is false "implement me"))

--- a/test/migratus/test/migrations.clj
+++ b/test/migratus/test/migrations.clj
@@ -1,0 +1,58 @@
+(ns migratus.test.migrations
+  (:require [clojure.test :refer :all]
+            [migratus.migrations :refer :all]))
+
+(deftest test-parse-name
+  (is (= ["20111202110600" "create-foo-table" "up"]
+         (parse-name "20111202110600-create-foo-table.up.sql")))
+  (is (= ["20111202110600" "create-foo-table" "down"]
+         (parse-name "20111202110600-create-foo-table.down.sql"))))
+
+(deftest test-find-migrations
+  (is (= {"20111202113000"
+          {"down" {:id        "20111202113000"
+                   :name      "create-bar-table"
+                   :direction "down"
+                   :content   "DROP TABLE IF EXISTS bar;\n"}
+           "up"   {:id        "20111202113000"
+                   :name      "create-bar-table"
+                   :direction "up"
+                   :content   "CREATE TABLE IF NOT EXISTS bar(id BIGINT);\n"}}
+          "20111202110600"
+          {"up"   {:id        "20111202110600"
+                   :name      "create-foo-table"
+                   :direction "up"
+                   :content   "CREATE TABLE IF NOT EXISTS foo(id bigint);\n"}
+           "down" {:id        "20111202110600"
+                   :name      "create-foo-table"
+                   :direction "down"
+                   :content   "DROP TABLE IF EXISTS foo;\n"}}
+          "20120827170200"
+          {"up"   {:id        "20120827170200"
+                   :name      "multiple-statements"
+                   :direction "up"
+                   :content   (str "-- this is the first statement\n\n"
+                                   "CREATE TABLE\nquux\n"
+                                   "(id bigint,\n"
+                                   " name varchar(255));\n\n"
+                                   "--;;\n"
+                                   "-- comment for the second statement\n\n"
+                                   "CREATE TABLE quux2(id bigint, name varchar(255));\n")}
+           "down" {:id        "20120827170200"
+                   :name      "multiple-statements"
+                   :direction "down"
+                   :content   (str "DROP TABLE quux2;\n"
+                                   "--;;\n"
+                                   "DROP TABLE quux;\n")}}}
+         (find-migrations "migrations" #{"init.sql"}))))
+
+(deftest test-find-jar-migrations
+  (is (= {"20111214173500"
+          {"down" {:id        "20111214173500"
+                   :name      "create-baz-table"
+                   :direction "down", :content "DROP TABLE IF EXISTS baz;\n"}
+           "up"   {:id        "20111214173500"
+                   :name      "create-baz-table"
+                   :direction "up"
+                   :content   "CREATE TABLE IF NOT EXISTS baz(id bigint);\n"}}}
+         (find-migrations "jar-migrations" #{"init.sql"}))))


### PR DESCRIPTION
We're using migratus for scripted SQL migrations, but have found ourselves wanting to write Clojure code to run as migrations as well (see the readme for some motivating use cases). Accomplishing this in the manner that we wanted involved teasing apart the Migration and Store protocols so they're less interdependent, and generalizing the way that migration files are listed and parsed.

The intent is to make all changes 100% backwards-compatible for existing users, and I think I've managed to succeed in that. Some slight changes to private function signatures in `migratus.core` were required.