### PR TITLE
Feature/save metadata #104

### DIFF
--- a/test/migratus/test/database.clj
+++ b/test/migratus/test/database.clj
@@ -253,9 +253,7 @@
                 {:id 20120827170200,
                  :description "multiple-statements"})))
        (testing "applied are timestamps")
-       (is (every? identity (map #(-> %
-                                      :applied
-                                      type
-                                      (= java.sql.Timestamp))
-                                 from-db)))))))
+       (is (every? (partial = java.sql.Timestamp)
+                   (map #(-> % :applied type) from-db)))))))
+
 

--- a/test/migratus/test/database.clj
+++ b/test/migratus/test/database.clj
@@ -239,20 +239,23 @@
 
 
 (deftest test-description-and-applied-fields
-  (core/migrate config)  
-  (let [from-db (verify-data config (:migration-table-name config))]
-    (testing "descriptions match")
-    (is (= (map #(dissoc % :applied) from-db)
-           '({:id 20111202110600,
-              :description "create-foo-table"}
-             {:id 20111202113000,
-              :description "create-bar-table"}
-             {:id 20120827170200,
-              :description "multiple-statements"})))
-    (testing "applied are timestamps")
-    (is (every? identity (map #(-> %
-                                   :applied
-                                   type
-                                   (= java.sql.Timestamp))
-                              from-db)))))
+  (test-with-store
+   (proto/make-store config)
+   (fn [{:keys [db migration-table-name] :as config}]
+     (core/migrate config)  
+     (let [from-db (verify-data config migration-table-name)]
+       (testing "descriptions match")
+       (is (= (map #(dissoc % :applied) from-db)
+              '({:id 20111202110600,
+                 :description "create-foo-table"}
+                {:id 20111202113000,
+                 :description "create-bar-table"}
+                {:id 20120827170200,
+                 :description "multiple-statements"})))
+       (testing "applied are timestamps")
+       (is (every? identity (map #(-> %
+                                      :applied
+                                      type
+                                      (= java.sql.Timestamp))
+                                 from-db)))))))
 


### PR DESCRIPTION
Support saving metadata in the database with the migration: human-readable description, and timestamp that the migration was applied.