### PR TITLE
Fix signature of update-migration-table!

### DIFF
--- a/src/migratus/database.clj
+++ b/src/migratus/database.clj
@@ -176,7 +176,7 @@
 
 (defn update-migration-table!
   "Updates the schema for the migration table via t-con in db in table-name"
-  [t-con db modify-sql-fn table-name]
+  [db modify-sql-fn table-name]
   (log/info "updating migration table" (str "'" table-name "'"))
   (sql/with-db-transaction
     [t-con db]


### PR DESCRIPTION
It appears that the `t-con` parameter of `migratus.database/update-migration-table!` is not actually supposed to be there. It is not used in the function; instead, it's shadowed by the binding with the same name in `with-db-connection`. Also, `migratus.database/init-schema!` is calling this function without supplying the transaction parameter, leading to _clojure.lang.ArityException: Wrong number of args (3) passed to: database/update-migration-table!_

It seems that the function works correctly and is called correctly if we simply remove the first parameter.