### PR TITLE
Remove upgrading instructions in README

### DIFF
--- a/README.org
+++ b/README.org
@@ -29,12 +29,6 @@
   Migratus does not use a single global version for a store.  It considers each
   migration independently, and runs all uncompleted migrations in sorted order.
 
-** Upgrading
-
-See [[https://github.com/yogthos/migratus/blob/master/CHANGES.md][changelog]] for changes.
-If you're upgrading from version below 0.9.1, you need to update the schema migations table
-to add a timestamp column.
-
 ** Quick Start
 
   - add the Migratus dependency:


### PR DESCRIPTION
This was misleading because migratus now automatically migrates its own schema if it is out of date. See https://github.com/yogthos/migratus/issues/113 If you try to follow these directions, you end up getting an error about the new columns already existing.
