### PR TITLE
Implement option for non-transaction migrations

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"
             :distribution :repo}
   :aliases {"test!" ["do" "clean," "test"]}
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/java.classpath "0.2.3"]
                  [org.clojure/java.jdbc "0.7.1"]
                  [org.clojure/tools.logging "0.3.1"]]

--- a/src/migratus/database.clj
+++ b/src/migratus/database.clj
@@ -76,12 +76,10 @@
         table-name (migration-table-name config)]
     (if (mark-reserved db table-name)
       (try
-        (sql/with-db-transaction
-          [t-con db]
-          (when (complete? t-con table-name id)
-            (proto/down migration (assoc config :conn t-con))
-            (mark-not-complete t-con table-name id)
-            :success))
+        (when (complete? db table-name id)
+          (proto/down migration (assoc config :conn db))
+          (mark-not-complete db table-name id)
+          :success)
         (finally
           (mark-unreserved db table-name)))
       :ignore)))

--- a/src/migratus/migration/edn.clj
+++ b/src/migratus/migration/edn.clj
@@ -9,6 +9,7 @@
   proto/Migration
   (id [this] id)
   (name [this] name)
+  (tx? [this direction] true)
   (up [this config]
     (when up-fn
       (up-fn config)))

--- a/src/migratus/migration/sql.clj
+++ b/src/migratus/migration/sql.clj
@@ -58,7 +58,7 @@
     name)
   (tx? [this direction]
     (if-let [sql (get this direction)]
-      (not (str/starts-with? sql "-- :disable-transaction\n"))
+      (use-tx? sql)
       (throw (Exception. (format "SQL %s commands not found for %d" direction id)))))
   (up [this config]
     (if up

--- a/src/migratus/migration/sql.clj
+++ b/src/migratus/migration/sql.clj
@@ -1,8 +1,11 @@
 (ns migratus.migration.sql
-  (:require [clojure.java.jdbc :as sql]
-            [clojure.tools.logging :as log]
-            [migratus.protocols :as proto])
-  (:import java.util.regex.Pattern))
+  (:require
+    [clojure.java.jdbc :as sql]
+    [clojure.string :as str]
+    [clojure.tools.logging :as log]
+    [migratus.protocols :as proto])
+  (:import
+    java.util.regex.Pattern))
 
 (def sep (Pattern/compile "^.*--;;.*\r?\n" Pattern/MULTILINE))
 (def sql-comment (Pattern/compile "^--.*" Pattern/MULTILINE))
@@ -19,23 +22,32 @@
        (remove empty?)
        (not-empty)))
 
-(defn execute-command [t-con c]
+(defn execute-command [t-con tx? c]
   (log/trace "executing" c)
   (try
-    (sql/db-do-prepared t-con c)
+    (sql/db-do-prepared t-con tx? c)
     (catch Throwable t
       (log/error (format "failed to execute command:\n %s\nFailure: %s" c (.getMessage t)))
       (throw t))))
 
-(defn run-sql [{:keys [conn db modify-sql-fn]} sql direction]
-  (sql/with-db-transaction
-    [t-con (or conn db)]
-    (when-let [commands (map (or modify-sql-fn identity) (split-commands sql))]
-      (log/debug "found" (count commands) (name direction) "migrations")
-      (doseq [c commands]
-        (execute-command t-con c)))))
+(defn- run-sql*
+  [conn tx? commands direction]
+  (log/debug "found" (count commands) (name direction) "migrations")
+  (doseq [c commands]
+    (execute-command conn tx? c)))
 
-(defrecord SqlMigration [id name up down]
+(defn run-sql
+  [{:keys [conn db modify-sql-fn]} tx? sql direction]
+  (when-let [commands (map (or modify-sql-fn identity) (split-commands sql))]
+    (if tx?
+      (sql/with-db-transaction
+        [t-con (or conn db)]
+        (run-sql* t-con true commands direction))
+      (sql/with-db-connection
+        [t-con (or conn db)]
+        (run-sql* t-con false commands direction)))))
+
+(defrecord SqlMigration [id name up down tx?]
   proto/Migration
   (id [this]
     id)
@@ -43,16 +55,22 @@
     name)
   (up [this config]
     (if up
-      (run-sql config up :up)
+      (run-sql config tx? up :up)
       (throw (Exception. (format "Up commands not found for %d" id)))))
   (down [this config]
     (if down
-      (run-sql config down :down)
+      (run-sql config tx? down :down)
       (throw (Exception. (format "Down commands not found for %d" id))))))
 
 (defmethod proto/make-migration* :sql
   [_ mig-id mig-name payload config]
-  (->SqlMigration mig-id mig-name (:up payload) (:down payload)))
+  (let [up (when-let [sql (:up payload)]
+             (if (string? sql) sql (:notx sql)))
+        down (when-let [sql (:down payload)]
+               (if (string? sql) sql (:notx sql)))
+        tx? (and (nil? (get-in payload [:up :notx]))
+                 (nil? (get-in payload [:down :notx])))]
+    (->SqlMigration mig-id mig-name up down tx?)))
 
 
 (defmethod proto/get-extension* :sql

--- a/src/migratus/protocols.clj
+++ b/src/migratus/protocols.clj
@@ -17,6 +17,7 @@
 (defprotocol Migration
   (id [this] "Id of this migration.")
   (name [this] "Name of this migration")
+  (tx? [this direction] "Whether this migration should run in a transaction.")
   (up [this config] "Bring this migration up.")
   (down [this config] "Bring this migration down."))
 


### PR DESCRIPTION
I really don't love this implementation, but I thought I'd get conversation started. We're using a PostgreSQL database and using the built in enum types, which you can create like:
```sql
CREATE TYPE category AS ENUM ('foo', 'bar', 'baz');
```
Later we want to expand the categories, so we made a migration to do so:
```sql
ALTER TYPE category ADD VALUE 'qux';
```
However this throws the following exception:

> org.postgresql.util.PSQLException: ERROR: ALTER TYPE ... ADD cannot run inside a transaction block

Hence the need for something like this PR, which adds support for naming a migration `{id}-{name}.notx.{up,down}.sql` to flag it to run outside of a transaction context. (Alternately, could make the first part `{id}-{name}[-notx]`, which might be simpler?) This required a surprising amount of plumbing in the code, but it works.

Any thoughts on how to support this more cleanly are welcome.