### PR TITLE
Fix init-script exclude when migrations are in a jar

### DIFF
--- a/src/migratus/migrations.clj
+++ b/src/migratus/migrations.clj
@@ -80,7 +80,7 @@
              (warn-on-invalid-migration file-name))))
        (remove nil?)))
 
-(defn find-migration-resources [dir jar init-script-name]
+(defn find-migration-resources [dir jar exclude-scripts]
   (log/debug "Looking for migrations in" dir jar)
   (->> (for [entry (enumeration-seq (.entries jar))
              :when (.matches (.getName ^JarEntry entry)
@@ -90,7 +90,7 @@
            (let [w (StringWriter.)]
              (io/copy (.getInputStream ^JarFile jar entry) w)
              (migration-map mig (.toString w)))
-           (when (not= entry-name init-script-name)
+           (when-not (exclude-scripts entry-name)
              (warn-on-invalid-migration entry-name))))
        (remove nil?)))
 

--- a/src/migratus/migrations.clj
+++ b/src/migratus/migrations.clj
@@ -70,7 +70,7 @@
             content))
 
 (defn find-migration-files [migration-dir exclude-scripts]
-  (log/debug "Looking for migrations in in " migration-dir)
+  (log/debug "Looking for migrations in" migration-dir)
   (->> (for [f (filter (fn [^File f] (.isFile f))
                        (file-seq migration-dir))
              :let [file-name (.getName ^File f)]]
@@ -81,7 +81,7 @@
        (remove nil?)))
 
 (defn find-migration-resources [dir jar init-script-name]
-  (log/debug "Looking for migrations in in " dir jar)
+  (log/debug "Looking for migrations in" dir jar)
   (->> (for [entry (enumeration-seq (.entries jar))
              :when (.matches (.getName ^JarEntry entry)
                              (str "^" (Pattern/quote dir) ".+"))


### PR DESCRIPTION
I was receiving the following warning:
```
  skipping: 'init.sql' migrations must match pattern: ^(\d+)-([^\.]+)((?:\.[^\.]+)+)$
```

despite using the configuration:
```
   { :init-script "init.sql" ... }
```

The problem was that `find-migration-resources` was treating its third argument as a String instead of the Set it actually was. This change uses the Set as intended and renames the parameter to match its content.