### PR TITLE
add test for backing out reserved issue with tx/no-tx

### DIFF
--- a/test/migrations-intentionally-broken-no-tx/20120827170200-multiple-statements-broken.down.sql
+++ b/test/migrations-intentionally-broken-no-tx/20120827170200-multiple-statements-broken.down.sql
@@ -1,0 +1,4 @@
+-- :disable-transaction
+DROP TABLE quux2;
+--;;
+DROP TABLE quux3;

--- a/test/migrations-intentionally-broken-no-tx/20120827170200-multiple-statements-broken.up.sql
+++ b/test/migrations-intentionally-broken-no-tx/20120827170200-multiple-statements-broken.up.sql
@@ -1,0 +1,16 @@
+-- :disable-transaction
+
+CREATE TABLE
+quux2
+(id bigint,
+ name varchar(255));
+
+--;;
+THIS IS MOST DEFINITELY NOT VALID SQL;
+
+--;;
+
+CREATE TABLE
+quux3
+(id bigint,
+ name varchar(255));


### PR DESCRIPTION
see https://github.com/yogthos/migratus/issues/132
`test-backing-out-bad-migration` should fail, while  `test-backing-out-bad-migration-no-tx` should pass