### PR TITLE
Introduce :expect-results? config that allows comparing rows 

### DIFF
--- a/src/migratus/migration/sql.clj
+++ b/src/migratus/migration/sql.clj
@@ -5,50 +5,74 @@
     [clojure.tools.logging :as log]
     [migratus.protocols :as proto])
   (:import
+    java.sql.SQLException
     java.util.regex.Pattern))
 
 (def sep (Pattern/compile "^.*--;;.*\r?\n" Pattern/MULTILINE))
 (def sql-comment (Pattern/compile "^--.*" Pattern/MULTILINE))
+(def sql-comment-without-expect (Pattern/compile "^--((?! *expect).)*$" Pattern/MULTILINE))
 (def empty-line (Pattern/compile "^[ ]+" Pattern/MULTILINE))
 
 (defn use-tx? [sql]
   (not (str/starts-with? sql "-- :disable-transaction")))
 
-(defn sanitize [command]
+(defn sanitize [command expect-results?]
   (-> command
-      (clojure.string/replace sql-comment "")
+      (clojure.string/replace (if expect-results? sql-comment-without-expect sql-comment) "")
       (clojure.string/replace empty-line "")))
 
-(defn split-commands [commands]
+(defn split-commands [commands expect-results?]
   (->> (.split sep commands)
-       (map sanitize)
+       (map #(sanitize % expect-results?))
        (remove empty?)
        (not-empty)))
 
-(defn execute-command [t-con tx? c]
+(defn check-expectations [result c]
+  (let [[full-str expect-str command] (re-matches #"(?sm).*\s*-- expect (.*);;\n+(.*)" c)]
+    (assert expect-str (str "No expectation on command: " c))
+    (let [expected (some-> expect-str Long/parseLong)
+          actual (some-> result first)
+          different? (not= actual expected)
+          message (format "%s %d"
+                          (some-> command (clojure.string/split #"\s+" 2) first clojure.string/upper-case)
+                          actual)]
+      (if different?
+        (log/error message "Expected" expected)
+        (log/info message)))))
+
+(defn execute-command [t-con tx? expect-results? c]
   (log/trace "executing" c)
-  (try
-    (sql/db-do-commands t-con tx? [c])
-    (catch Throwable t
-      (log/error (format "failed to execute command:\n %s\nFailure: %s" c (.getMessage t)))
-      (throw t))))
+  (cond->
+    (try
+      (sql/db-do-commands t-con tx? [c])
+      (catch SQLException e
+        (log/error (format "failed to execute command:\n %s" c))
+        (loop [e e]
+          (if-let [next-e (.getNextException e)]
+            (recur next-e)
+            (log/error (.getMessage e))))
+        (throw e))
+      (catch Throwable t
+        (log/error (format "failed to execute command:\n %s\nFailure: %s" c (.getMessage t)))
+        (throw t)))
+    expect-results? (check-expectations c)))
 
 (defn- run-sql*
-  [conn tx? commands direction]
+  [conn tx? expect-results? commands direction]
   (log/debug "found" (count commands) (name direction) "migrations")
   (doseq [c commands]
-    (execute-command conn tx? c)))
+    (execute-command conn tx? expect-results? c)))
 
 (defn run-sql
-  [{:keys [conn db modify-sql-fn]} sql direction]
-  (when-let [commands (map (or modify-sql-fn identity) (split-commands sql))]
+  [{:keys [conn db modify-sql-fn expect-results?]} sql direction]
+  (when-let [commands (map (or modify-sql-fn identity) (split-commands sql expect-results?))]
     (if (use-tx? sql)
       (sql/with-db-transaction
         [t-con (or conn db)]
-        (run-sql* t-con true commands direction))
+        (run-sql* t-con true expect-results? commands direction))
       (sql/with-db-connection
         [t-con (or conn db)]
-        (run-sql* t-con false commands direction)))))
+        (run-sql* t-con false expect-results? commands direction)))))
 
 (defrecord SqlMigration [id name up down]
   proto/Migration


### PR DESCRIPTION
This PR might be a bit too specific to to our needs but we thought we'd contribute it if people are interested or if you think it could be useful to others.

We ran into a production bug where we accidentally deleted too much data because of a missing where clause on a `DELETE` statement. So we decided we wanted better logging of migrations in two ways:
- See how many rows were affected by each statement similar to running the migration file through `psql -f migration.sql`
- Be able to annotate the migrations with how many rows we expected to be changed.

An example 

```
-- expect 0;;
-- 20180928110216-foobartest.up.sql
create table foobar (thing text);

--;;
-- expect 18;;
insert into foobar values ('a'), ('a'), ('a'), ('a'), ('a'), ('a'), ('a'), ('a'), ('a'), ('a'), ('a'), ('a'), ('a'), ('a'), ('a'), ('a'), ('a'), ('a'), ('b');

--;;

-- expect 17;;

update foobar set thing = 'c' where thing = 'a';

--;;
-- expect 1;;
delete from foobar where thing = 'c';

--;;
-- expect 100000;;
delete from svc.incident_attributes;
```

```
2018-10-01 20:27:47.046 migratus.core  INFO   Running up for [20180928110216 20181001103554]
2018-10-01 20:27:47.047 migratus.core  INFO   Up 20180928110216-foobartest
2018-10-01 20:27:47.061 migratus.migration.sql  DEBUG  found 5 up migrations
2018-10-01 20:27:47.070 migratus.migration.sql  INFO   CREATE 0
2018-10-01 20:27:47.076 migratus.migration.sql  ERROR  INSERT 19 Expected 18
2018-10-01 20:27:47.079 migratus.migration.sql  ERROR  UPDATE 18 Expected 17
2018-10-01 20:27:47.081 migratus.migration.sql  ERROR  DELETE 18 Expected 1
2018-10-01 20:27:47.084 migratus.migration.sql  ERROR  DELETE 0 Expected 100000
2018-10-01 20:27:47.085 migratus.database  DEBUG  marking 20180928110216 complete
```
