### PR TITLE
Avoid unnecessary calls by reflection.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject migratus "1.2.0"
+(defproject migratus "1.2.1-SNAPSHOT"
   :description "MIGRATE ALL THE THINGS!"
   :url "http://github.com/yogthos/migratus"
   :license {:name "Apache License, Version 2.0"

--- a/src/migratus/migration/sql.clj
+++ b/src/migratus/migration/sql.clj
@@ -8,10 +8,10 @@
     java.sql.SQLException
     java.util.regex.Pattern))
 
-(def sep (Pattern/compile "^.*--;;.*\r?\n" Pattern/MULTILINE))
-(def sql-comment (Pattern/compile "^--.*" Pattern/MULTILINE))
-(def sql-comment-without-expect (Pattern/compile "^--((?! *expect).)*$" Pattern/MULTILINE))
-(def empty-line (Pattern/compile "^[ ]+" Pattern/MULTILINE))
+(def ^Pattern sep (Pattern/compile "^.*--;;.*\r?\n" Pattern/MULTILINE))
+(def ^Pattern sql-comment (Pattern/compile "^--.*" Pattern/MULTILINE))
+(def ^Pattern sql-comment-without-expect (Pattern/compile "^--((?! *expect).)*$" Pattern/MULTILINE))
+(def ^Pattern empty-line (Pattern/compile "^[ ]+" Pattern/MULTILINE))
 
 (defn use-tx? [sql]
   (not (str/starts-with? sql "-- :disable-transaction")))

--- a/src/migratus/migrations.clj
+++ b/src/migratus/migrations.clj
@@ -17,8 +17,8 @@
         (fn [s c]
           (if (and
                 (not-empty s)
-                (Character/isLowerCase (last s))
-                (Character/isUpperCase c))
+                (Character/isLowerCase (char (last s)))
+                (Character/isUpperCase (char c)))
             (str s "-" c)
             (str s c)))
         "" s)
@@ -75,13 +75,13 @@
              :let [file-name (.getName ^File f)]]
          (if-let [mig (parse-name file-name)]
            (migration-map mig (slurp f))
-           (when-not (exclude-scripts (.getName f))
+           (when-not (exclude-scripts (.getName ^File f))
              (warn-on-invalid-migration file-name))))
        (remove nil?)))
 
 (defn find-migration-resources [dir jar exclude-scripts]
   (log/debug "Looking for migrations in" dir jar)
-  (->> (for [entry (enumeration-seq (.entries jar))
+  (->> (for [entry (enumeration-seq (.entries ^JarFile jar))
              :when (.matches (.getName ^JarEntry entry)
                              (str "^" (Pattern/quote dir) ".+"))
              :let [entry-name (.replaceAll (.getName ^JarEntry entry) dir "")]]
@@ -154,5 +154,5 @@
         migration-name (->kebab-case name)
         pattern        (re-pattern (str "[\\d]*-" migration-name "\\..*"))
         migrations     (file-seq migration-dir)]
-    (doseq [f (filter #(re-find pattern (.getName %)) migrations)]
-      (.delete f))))
+    (doseq [f (filter #(re-find pattern (.getName ^File %)) migrations)]
+      (.delete ^File f))))

--- a/src/migratus/utils.clj
+++ b/src/migratus/utils.clj
@@ -1,8 +1,7 @@
 (ns migratus.utils
   (:import java.io.File
-           java.net.URLDecoder
            java.util.jar.JarFile
-           java.util.regex.Pattern)
+           [java.net URL URLDecoder])
   (:require [clojure.string :as str]))
 
 (def default-migration-parent "resources/")
@@ -37,12 +36,12 @@
     (str dir "/")
     dir))
 
-(defn jar-file [url]
+(defn jar-file [^URL url]
   (some-> url
           (.getFile)
           (URLDecoder/decode "UTF-8")
           (.split "!/")
-          (first)
+          ^String (first)
           (.replaceFirst "file:" "")
           (JarFile.)))
 
@@ -50,13 +49,13 @@
   "Finds the given directory on the classpath. For backward
   compatibility, tries the System ClassLoader first, but falls back to
   using the Context ClassLoader like Clojure's compiler."
-  ([dir]
+  ([^String dir]
    (or (find-migration-dir (ClassLoader/getSystemClassLoader) dir)
        (-> (Thread/currentThread)
            (.getContextClassLoader)
            (find-migration-dir dir))))
-  ([class-loader dir]
-   (when-let [url (.getResource class-loader dir)]
+  ([^ClassLoader class-loader ^String dir]
+   (when-let [^URL url (.getResource class-loader dir)]
      (if (= "jar" (.getProtocol url))
        (jar-file url)
        (File. (URLDecoder/decode (.getFile url) "UTF-8"))))))


### PR DESCRIPTION
Hi, I experimented with Graal native-image and it went well with Migratus. However the resulting binary had some issues with reflective calls. It can be worked around by having an extra configuration file for native-image and enumerating all the cases there or just by getting rid of those calls. This patch implements the second approach. No changes of the functionality.