### PR TITLE
Filesystem lookup and complementary operation to pending migrations.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject migratus "1.2.1"
+(defproject migratus "1.2.2"
   :description "MIGRATE ALL THE THINGS!"
   :url "http://github.com/yogthos/migratus"
   :license {:name "Apache License, Version 2.0"

--- a/test/migratus/test/core.clj
+++ b/test/migratus/test/core.clj
@@ -124,6 +124,16 @@
       (destroy config migration)
       (io/delete-file (io/file "test" migration-dir)))))
 
+(deftest test-completed-list
+  (let [ups    (atom [])
+        downs  (atom [])
+        config {:store         :mock
+                :completed-ids (atom #{1 2 3})}]
+    (with-redefs [mig/list-migrations (constantly (migrations ups downs))]
+      (testing "should return the list of completed migrations"
+        (is (= ["id-1" "id-2" "id-3"]
+               (migratus.core/completed-list config)))))))
+
 (deftest test-pending-list
   (let [ups    (atom [])
         downs  (atom [])
@@ -134,6 +144,17 @@
         (is (= ["id-2" "id-3" "id-4"]
                (migratus.core/pending-list config)))))))
 
+(deftest test-select-migrations
+  (let [ups    (atom [])
+        downs  (atom [])
+        config {:store         :mock
+                :completed-ids (atom #{1 3})}]
+    (with-redefs [mig/list-migrations (constantly (migrations ups downs))]
+      (testing "should return the list of [id name] selected migrations"
+        (is (= [[1 "id-1"] [3 "id-3"]]
+               (migratus.core/select-migrations config migratus.core/completed-migrations)))
+        (is (= [[2 "id-2"] [4 "id-4"]]
+               (migratus.core/select-migrations config migratus.core/uncompleted-migrations)))))))
 
 (deftest supported-extensions
   (testing "All supported extensions show up.


### PR DESCRIPTION
As suggested in #162 I cut out the application code and created a repository for native Standalone Migration Runner (currently limited to PostgreSQL).

See [PGMig repo](https://github.com/leafclick/pgmig). If you have a PostgreSQL server running you can give it a go. It's a first draft but it should work.

Native-image means to resource lookup are inherently much more limited than in plain java. For a standalone tool it meant that `find-migration-dir` needed to be enhanced to allow filesystem access.

The first patch enables the FS lookup in a backward compatible way.

To better support the runner (which is harder to debug than a java app) I added more detailed output and a `list` operation support code in Migratus (the second patch). 