### PR TITLE
Censor password on connection exception message

### DIFF
--- a/src/migratus/database.clj
+++ b/src/migratus/database.clj
@@ -115,7 +115,7 @@
         (try
           (sql/get-connection db)
           (catch Exception e
-            (log/error e (str "Error creating DB connection for " db))))]
+            (log/error e (str "Error creating DB connection for " (utils/censor-password db)))))]
     (.setAutoCommit conn false)
     {:connection conn}))
 

--- a/src/migratus/utils.clj
+++ b/src/migratus/utils.clj
@@ -86,3 +86,12 @@
   "Replace backslashes with forwardslashes"
   [^String s]
   (str/replace s "\\" "/"))
+
+(defn censor-password
+  "Show only first character of password if given db-spec has password"
+  [{:keys [password] :as db-spec}]
+  (if (empty? password)
+    db-spec
+    (assoc db-spec
+      :password (str (subs password 0 (min 1 (count password)))
+                     "<censored>"))))

--- a/test/migratus/test/utils.clj
+++ b/test/migratus/test/utils.clj
@@ -1,0 +1,10 @@
+(ns migratus.test.utils
+  (:require [clojure.test :refer :all]
+            [migratus.utils :refer :all]))
+
+(deftest test-censor-password
+  (is (= nil (censor-password nil)))
+  (is (= "" (censor-password "")))
+  (is (= {:password nil} (censor-password {:password nil})))
+  (is (= {:password "1<censored>" :user "user"}
+         (censor-password {:password "1234" :user "user"}))))


### PR DESCRIPTION
Fix a plain text password leak to logs in a case database connection
fails during migration startup.