### PR TITLE
WIP: Make it possible to pass in existing connection/data-source

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,33 @@ Next, create a namespace to manage the migrations:
 (migratus/down config 20111206154000)
 ```
 
+#### Alternative setup
+
+It is possible to pass a `java.sql.Connection` or `javax.sql.DataSource` in place of a db spec map, e.g:
+
+```clojure
+(ns my-migrations
+  (:require [clojure.java.jdbc :as jdbc]))
+
+(def connection (jdbc/get-connection
+                  {:classname   "org.h2.Driver"
+                   :subprotocol "h2"
+                   :subname     "site.db"}))
+
+(def config {:db connection})
+```
+
+```clojure
+(ns my-migrations
+  (:require [hikari-cp :as hk]))
+;; Hikari: https://github.com/tomekw/hikari-cp
+
+(def datasource-options {:adapter "h2"
+                         :url     "jdbc:h2:site.db"})
+
+(def config {:db (hk/make-datasource datasource-options)})
+```
+
 ### Generate migration files
 
 Migratus also provides a convenience function for creating migration files:

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject migratus "1.2.3"
+(defproject migratus "1.2.4-SNAPSHOT"
   :description "MIGRATE ALL THE THINGS!"
   :url "http://github.com/yogthos/migratus"
   :license {:name "Apache License, Version 2.0"
@@ -10,4 +10,5 @@
                  [org.clojure/tools.logging "0.4.1"]]
   :profiles {:dev {:dependencies [[jar-migrations "1.0.0"]
                                   [ch.qos.logback/logback-classic "1.2.3"]
-                                  [com.h2database/h2 "1.4.197"]]}})
+                                  [com.h2database/h2 "1.4.197"]
+                                  [hikari-cp "2.8.0"]]}})


### PR DESCRIPTION
Let me know what you think about the approach @yogthos. This is still work in progress, some details to fix.

This commit adds code to let library users pass a java.sql.Connection or a
javax.sql.DataSource instance in place of a Clojure map for the :db key in the
configuration map.

The connect* function will make a type check on the db value. If the value is a
DataSource it will get a connection from the data-source. If it is a Connection
it will simply use that connection. If not, it will default to creating its own
Connection as before.

TODO: Figure out how to test data-source based store creation.

See issue #172 .