### PR TITLE
fixed transactional mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### 1.2.5
+
+fixed error for transactional mode.
+
 ### 1.2.4
 
 [support for passing in an existing connection](https://github.com/yogthos/migratus/pull/172)

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject migratus "1.2.4"
+(defproject migratus "1.2.5"
   :description "MIGRATE ALL THE THINGS!"
   :url "http://github.com/yogthos/migratus"
   :license {:name "Apache License, Version 2.0"


### PR DESCRIPTION
we can't create database for PostgreSQL inside init.sql cause migratus always works in transactional mode despite :init-in-transaction? false parameter.

This PR fix this issue.