### PR TITLE
Wrap modify-sql-fn to support returning a sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,8 +340,9 @@ See test/migrations in this repository for an example of how database migrations
 
 ### Modify sql fn
 
-If you want to do some processing of the sql before it gets executed, you can provide a `:modify-sql-fn` in the config data structure to do so. This is intended for use with http://2ndquadrant.com/en/resources/pglogical/ and similar
-systems, where DDL statements need to be executed via an extension-provided function.
+If you want to do some processing of the sql before it gets executed, you can provide a `:modify-sql-fn` in the config data structure to do so.
+It expects a sql-string and can return either a modified sql-string or a sequence of sql-strings.
+This is intended for use with http://2ndquadrant.com/en/resources/pglogical/ and similar systems, where DDL statements need to be executed via an extension-provided function.
 
 ## Usage
    Migratus can be used programmatically by calling one of the following functions:

--- a/src/migratus/database.clj
+++ b/src/migratus/database.clj
@@ -250,7 +250,7 @@
         (init-db! conn
                   (utils/get-migration-dir config)
                   (utils/get-init-script config)
-                  (get config :modify-sql-fn identity)
+                  (sql-mig/wrap-modify-sql-fn (:modify-sql-fn config))
                   (get config :init-in-transaction? true))
         (finally
           (disconnect* conn)))))
@@ -270,7 +270,7 @@
     (reset! connection (connect* (:db config)))
     (init-schema! @connection
                   (migration-table-name config)
-                  (get config :modify-sql-fn identity)))
+                  (sql-mig/wrap-modify-sql-fn (:modify-sql-fn config))))
   (disconnect [this]
     (disconnect* @connection)
     (reset! connection nil)))

--- a/test/migratus/test/database.clj
+++ b/test/migratus/test/database.clj
@@ -131,6 +131,12 @@
     (str "-- " sql)
     sql))
 
+(defn multi-bar-statements [sql]
+  (if (re-find #"CREATE TABLE IF NOT EXISTS bar" sql)
+    ["CREATE TABLE IF NOT EXISTS bar1"
+     "CREATE TABLE IF NOT EXISTS bar2"]
+    sql))
+
 (deftest test-migrate-with-modify-sql-fn
   (is (not (test-sql/verify-table-exists? config "foo")))
   (is (not (test-sql/verify-table-exists? config "bar")))
@@ -139,6 +145,19 @@
   (core/migrate (assoc config :modify-sql-fn comment-out-bar-statements))
   (is (test-sql/verify-table-exists? config "foo"))
   (is (not (test-sql/verify-table-exists? config "bar")))
+  (is (test-sql/verify-table-exists? config "quux"))
+  (is (test-sql/verify-table-exists? config "quux2")))
+
+(deftest test-migrate-with-multi-statement-modify-sql-fn
+  (is (not (test-sql/verify-table-exists? config "foo")))
+  (is (not (test-sql/verify-table-exists? config "bar")))
+  (is (not (test-sql/verify-table-exists? config "quux")))
+  (is (not (test-sql/verify-table-exists? config "quux2")))
+  (core/migrate (assoc config :modify-sql-fn multi-bar-statements))
+  (is (test-sql/verify-table-exists? config "foo"))
+  (is (not (test-sql/verify-table-exists? config "bar")))
+  (is (test-sql/verify-table-exists? config "bar1"))
+  (is (test-sql/verify-table-exists? config "bar2"))
   (is (test-sql/verify-table-exists? config "quux"))
   (is (test-sql/verify-table-exists? config "quux2")))
 


### PR DESCRIPTION
Still defaults to identity at call sites, but now will mapcat any commands that pass through it to be executed.

Allows turning `"create table bar"` into `["create table x.bar" "create table y.bar"]` and executing both commands.

I tried changing `proto/config` to do the wrapping but it got way hairier than replacing the `(or modify-sql-fn identity)` sites with the `wrap-modify-sql-fn` call.