### PR TITLE
Don't log connection-uri on connection failure

### DIFF
--- a/src/migratus/utils.clj
+++ b/src/migratus/utils.clj
@@ -87,11 +87,18 @@
   [^String s]
   (str/replace s "\\" "/"))
 
-(defn censor-password
-  "Show only first character of password if given db-spec has password"
+(defmulti censor-password class)
+
+(defmethod censor-password String [uri]
+  (if (empty? uri)
+    ""
+    "uri-censored"))
+
+(defmethod censor-password :default
   [{:keys [password] :as db-spec}]
   (if (empty? password)
     db-spec
+    ;; Show only first character of password if given db-spec has password
     (assoc db-spec
       :password (str (subs password 0 (min 1 (count password)))
                      "<censored>"))))

--- a/test/migratus/test/utils.clj
+++ b/test/migratus/test/utils.clj
@@ -7,4 +7,6 @@
   (is (= "" (censor-password "")))
   (is (= {:password nil} (censor-password {:password nil})))
   (is (= {:password "1<censored>" :user "user"}
-         (censor-password {:password "1234" :user "user"}))))
+         (censor-password {:password "1234" :user "user"})))
+  (is (= "uri-censored"
+         (censor-password "jdbc:postgresql://fake.rds.amazonaws.com/capital_thing?user=capital_db&password=thisIsNot123ARealPass"))))


### PR DESCRIPTION
An aggressive fix for [issue 189](https://github.com/yogthos/migratus/issues/189)

It simply replaces a non-empty string entirely, to avoid the difficulties of parsing the uri and removing only the password.
(This was suggested as an option by @jysandy when creating the bug.)

While not ideal, this is better than logging a password. 
Can we consider showing more information in this case as a future enhancement?

Context: luminus-migrations seem to require passing a URI rather than a db-spec, so [issue 189](https://github.com/yogthos/migratus/issues/189) affects all users of that library. 

