### PR TITLE
Don't log value of :connection-uri in db-spec

### DIFF
--- a/src/migratus/utils.clj
+++ b/src/migratus/utils.clj
@@ -95,10 +95,17 @@
     "uri-censored"))
 
 (defmethod censor-password :default
-  [{:keys [password] :as db-spec}]
-  (if (empty? password)
-    db-spec
-    ;; Show only first character of password if given db-spec has password
-    (assoc db-spec
-      :password (str (subs password 0 (min 1 (count password)))
-                     "<censored>"))))
+  [{:keys [password connection-uri] :as db-spec}]
+    (let [password-map
+          (if (empty? password)
+            nil
+            ;; Show only first character of password if given db-spec has password
+            {:password
+             (str (subs password 0 (min 1 (count password)))
+                  "<censored>")})
+          uri-map
+          (if (empty? connection-uri)
+            nil
+            ;; Censor entire uri instead of trying to parse out and replace only a possible password parameter
+            {:connection-uri "uri-censored"})]
+    (merge db-spec password-map uri-map)))

--- a/test/migratus/test/utils.clj
+++ b/test/migratus/test/utils.clj
@@ -9,4 +9,10 @@
   (is (= {:password "1<censored>" :user "user"}
          (censor-password {:password "1234" :user "user"})))
   (is (= "uri-censored"
-         (censor-password "jdbc:postgresql://fake.rds.amazonaws.com/capital_thing?user=capital_db&password=thisIsNot123ARealPass"))))
+         (censor-password
+           "jdbc:postgresql://fake.example.org/my_dev?user=my_user&password=thisIsNot123ARealPass")))
+  (is (= {:connection-uri "uri-censored"}
+         (censor-password {:connection-uri "jdbc:postgresql://fake.example.org/my_dev?user=my_user&password=thisIsNot123ARealPass"})))
+  (is (= {:connection-uri "uri-censored" :password "1<censored>" :user "user"}
+         (censor-password {:password "1234" :user "user"
+                           :connection-uri "jdbc:postgresql://fake.example.org/my_dev?user=my_user&password=thisIsNot123ARealPass"}))))


### PR DESCRIPTION
A fix for https://github.com/yogthos/migratus/issues/189

When logging the db-spec on a connection failure, it replaces a non-empty value
for key :connection-uri entirely, to avoid the difficulties of parsing the uri
and removing only the password.