### PR TITLE
Switch to new version of clj-migratus

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,40 +432,46 @@ And add a configuration :migratus key to your `project.clj`.
 
 ## Quickstart with native Clojure projects
 
-[![Clojars Project](https://img.shields.io/clojars/v/orangefoxcollective/clj-migratus.svg)](https://clojars.org/orangefoxcollective/clj-migratus)
-
-See [clj-migratus](https://gitlab.com/orangefoxcollective/clj-migratus) for more information.
+See [clj-migratus](https://github.com/paulbutcher/clj-migratus) for more information.
 
 ## Usage
 
 Add the following to your `deps.edn`:
 
-	:aliases
-	{:migratus {:extra-deps
-	            {orangefoxcollective/clj-migratus {:mvn/version "0.1.0"}}
-	            :main-opts ["-m" "clj-migratus.core"]}}
+```
+:aliases {:migrate {:extra-deps {com.github.paulbutcher/clj-migratus {:git/tag "v1.0.0"
+                                                                      :git/sha "67d0fe5"}}
+                     :main-opts ["-m" "clj-migratus"]}}
+```
 
+Create a [Migratus configuration](https://github.com/yogthos/migratus#configuration) file. This can either be `migratus.edn`:
 
-Create a [Migratus configuration](https://github.com/yogthos/migratus#configuration) file `migratus.edn`:
+```
+{:store :database
+ :migration-dir "migrations"
+ :db {:classname "com.mysql.jdbc.Driver"
+      :subprotocol "mysql"
+      :subname "//localhost/migratus"
+      :user "root"
+      :password ""}}
+```
 
-    {:store :database
-     :migration-dir "migrations"
-     :db {:classname "com.mysql.jdbc.Driver"
-	      :subprotocol "mysql"
-          :subname "//localhost/migratus"
-          :user "root"
-          :password ""}}
+Or (recommended) `migratus.clj`, allowing credentials to be taken from the environment:
 
-Then run `clj-migratus` via the command line. For example:
+```
+{:store :database
+ :db (get (System/getenv) "JDBC_DATABASE_URL")}
+```
 
-    $ clj -Amigratus init
+Then run, for example:
 
-    $ clj -Amigratus migrate
-
-    $ clj -Amigratus create create-user-table
-
+```
+$ clj -M:migrate init
+$ clj -M:migrate migrate
+$ clj -M:migrate create create-user-table
+```
+	
 See [Migratus Usage](https://github.com/yogthos/migratus#usage) for documentation on each command.
-
 
 ## License
 


### PR DESCRIPTION
https://gitlab.com/orangefoxcollective/clj-migratus doesn't seem to be maintained any longer, and forces database credentials to be encoded within `migratus.edn`.

I've created a new version: https://github.com/paulbutcher/clj-migratus

These changes modify the README to recommend this new version.