### PR TITLE
Fixes up coded migrations so that the database is not locked when trying to write to it. Fixes yogothos/migratus#203

### DIFF
--- a/src/migratus/migration/edn.clj
+++ b/src/migratus/migration/edn.clj
@@ -6,11 +6,11 @@
 
 ;; up-fn and down-fn here are actually vars; invoking them as fns will deref
 ;; them and invoke the fn bound by the var.
-(defrecord EdnMigration [id name up-fn down-fn]
+(defrecord EdnMigration [id name up-fn down-fn transaction?]
   proto/Migration
   (id [this] id)
   (name [this] name)
-  (tx? [this direction] true)
+  (tx? [this direction] (if (nil? transaction?) true  transaction?))
   (up [this config]
     (when up-fn
       (up-fn config)))
@@ -41,7 +41,7 @@
 
 (defmethod proto/make-migration* :edn
   [_ mig-id mig-name payload config]
-  (let [{:keys [ns up-fn down-fn]
+  (let [{:keys [ns up-fn down-fn transaction?]
          :or   {up-fn "up" down-fn "down"}} (edn/read-string payload)
         mig-ns (to-sym ns)]
     (when-not mig-ns
@@ -50,13 +50,12 @@
     (require mig-ns)
     (->EdnMigration mig-id mig-name
                     (resolve-fn mig-name mig-ns up-fn)
-                    (resolve-fn mig-name mig-ns down-fn))))
-
+                    (resolve-fn mig-name mig-ns down-fn)
+                    transaction?)))
 
 (defmethod proto/get-extension* :edn
   [_]
   "edn")
-
 
 (defmethod proto/migration-files* :edn
   [x migration-name]

--- a/test/migrations-edn/20170330142700-say-hello.edn
+++ b/test/migrations-edn/20170330142700-say-hello.edn
@@ -1,3 +1,4 @@
 {:ns migratus.test.migration.edn.test-script
  :up-fn migrate-up
- :down-fn migrate-down}
+ :down-fn migrate-down
+ :transaction? true}


### PR DESCRIPTION
Coded migrations were always opening a connection before calling the code in the migration namespace.

This change makes it configurable in the migration edn. For example,

    {:ns migratus-test.db.migrations.test-migration
     :up-fn test-migration
     :down-fn nil
     :transaction? false}