### PR TITLE
[DRAFT] #182 next jdbc migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ migratus.iml
 .portal
 .cpcache
 .calva/output-window/
+.clj-kondo/

--- a/README.md
+++ b/README.md
@@ -469,6 +469,18 @@ $ clj -M:migrate create create-user-table
 
 See [Migratus Usage](https://github.com/yogthos/migratus#usage) for documentation on each command.
 
+## Development
+
+```bash
+
+# Run tests via deps.edn (tools-deps), not project.clj (leiningen)
+clojure  -M:clojure1.11:dev:test-runner
+# Other options
+clojure  -M:clojure1.11:dev:test-runner --fail-fast
+
+clojure  -M:clojure1.11:dev:test-runner --focus migratus.test.database
+```
+
 ## License
 
 Copyright © 2016 Paul Stadig, Dmitri Sotnikov

--- a/README.md
+++ b/README.md
@@ -116,9 +116,8 @@ Additional property can be specified using the `:env` key or by providing a map 
 {:store :database
  :properties {:env ["database.table"]
               :map {:database {:user "bob"}}}
- :db {:classname   "org.h2.Driver"
-      :subprotocol "h2"
-      :subname     "site.db"}}
+ :db {:dbtype   "h2"
+      :dbname   "site.db"}}
 ```
 
 For example, given the following template:
@@ -161,9 +160,8 @@ Next, create a namespace to manage the migrations:
              ;schema initialization in a transaction
              :init-in-transaction? false
              :migration-table-name "foo_bar"
-             :db {:classname   "org.h2.Driver"
-                  :subprotocol "h2"
-                  :subname     "site.db"}})
+             :db {:dbtype "h2"
+                  :dbname "site.db"}})
 
 ;initialize the database using the 'init.sql' script
 (migratus/init config)
@@ -190,9 +188,8 @@ It is possible to pass a `java.sql.Connection` or `javax.sql.DataSource` in plac
   (:require [clojure.java.jdbc :as jdbc]))
 
 (def connection (jdbc/get-connection
-                  {:classname   "org.h2.Driver"
-                   :subprotocol "h2"
-                   :subname     "site.db"}))
+                  {:dbtype "h2"
+                   :dbname "site.db"}))
 
 (def config {:db {:connection connection}})
 ```
@@ -301,9 +298,8 @@ Migratus provides a Leiningen plugin:
 ```clojure
 :migratus {:store :database
            :migration-dir "migrations"
-           :db {:classname "com.mysql.jdbc.Driver"
-                :subprotocol "mysql"
-                :subname "//localhost/migratus"
+           :db {:dbtype "mysql"
+                :dbname "//localhost/migratus"
                 :user "root"
                 :password ""}}
 ```
@@ -340,9 +336,8 @@ To run migrations against a database use a :store of :database, and specify the 
 ```clojure
 {:store :database
  :migration-dir "migrations"
- :db {:classname "com.mysql.jdbc.Driver"
-      :subprotocol "mysql"
-      :subname "//localhost/migratus"
+ :db {:dbtype "mysql"
+      :dbname "migratus"
       :user "root"
       :password ""}}
 ```
@@ -395,7 +390,7 @@ This is intended for use with http://2ndquadrant.com/en/resources/pglogical/ and
    | `migratus.core/create`                    | Create a new migration with the current date.                                                                                                      |
    | `migratus.core/migrate`                   | Run `up` for any migrations that have not been run. Returns `nil` if successful, `:ignore` if the table is reserved. Supports thread cancellation. |
    | `migratus.core/rollback`                  | Run `down` for the last migration that was run.                                                                                                    |
-   | `migratus.core/rollback-until-just-after` | Run `down` all migrations after `migration-id`. This only considers completed migrations, and will not migrate up.                                 | 
+   | `migratus.core/rollback-until-just-after` | Run `down` all migrations after `migration-id`. This only considers completed migrations, and will not migrate up.                                 |
    | `migratus.core/up`                        | Run `up` for the specified migration ids. Will skip any migration that is already up.                                                              |
    | `migratus.core/down`                      | Run `down` for the specified migration ids. Will skip any migration that is already down.                                                          |
    | `migratus.core/pending-list`              | Returns a list of pending migrations.                                                                                                              |
@@ -414,9 +409,8 @@ And add a configuration :migratus key to your `project.clj`.
 ```clojure
 :migratus {:store :database
            :migration-dir "migrations"
-           :db {:classname "com.mysql.jdbc.Driver"
-                :subprotocol "mysql"
-                :subname "//localhost/migratus"
+           :db {:dbtype "mysql"
+                :dbname "migratus"
                 :user "root"
                 :password ""}}
 ```
@@ -452,9 +446,8 @@ Create a [Migratus configuration](https://github.com/yogthos/migratus#configurat
 ```
 {:store :database
  :migration-dir "migrations"
- :db {:classname "com.mysql.jdbc.Driver"
-      :subprotocol "mysql"
-      :subname "//localhost/migratus"
+ :db {:dbtype "mysql"
+      :dbname "migratus"
       :user "root"
       :password ""}}
 ```
@@ -473,7 +466,7 @@ $ clj -M:migrate init
 $ clj -M:migrate migrate
 $ clj -M:migrate create create-user-table
 ```
-	
+
 See [Migratus Usage](https://github.com/yogthos/migratus#usage) for documentation on each command.
 
 ## License

--- a/deps.edn
+++ b/deps.edn
@@ -4,17 +4,20 @@
  :license {:name "Apache License, Version 2.0"
            :url "http://www.apache.org/licenses/LICENSE-2.0.html"
            :distribution :repo}
- :deps {org.clojure/java.jdbc {:mvn/version "0.7.11"}
+ :deps {com.github.seancorfield/next.jdbc {:mvn/version "1.2.780"}
+        org.clojure/java.jdbc {:mvn/version "0.7.11"}
         org.clojure/tools.logging {:mvn/version "1.1.0"}}
  :aliases {:clojure1.10 {:extra-deps
                          {org.clojure/clojure {:mvn/version "1.10.1"}}}
            :clojure1.11 {:extra-deps
                          {org.clojure/clojure {:mvn/version "1.11.1"}}}
-           :dev {:extra-deps
+           :dev {:extra-paths ["test"]
+                 :extra-deps
                  {jar-migrations/jar-migrations {:mvn/version "1.0.0"}
                   ch.qos.logback/logback-classic {:mvn/version "1.2.3"}
                   com.h2database/h2 {:mvn/version "1.4.200"}
-                  hikari-cp/hikari-cp {:mvn/version "2.13.0"}}}
+                  hikari-cp/hikari-cp {:mvn/version "2.13.0"}
+                  org.clojure/tools.trace {:mvn/version "0.7.11"}}}
            :test-runner {:extra-paths ["test"]
                          :extra-deps
                          {jar-migrations/jar-migrations {:mvn/version "1.0.0"}

--- a/project.clj
+++ b/project.clj
@@ -5,10 +5,12 @@
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"
             :distribution :repo}
   :aliases {"test!" ["do" "clean," "test"]}
-  :dependencies [[org.clojure/clojure "1.10.1"]
+  :dependencies [[com.github.seancorfield/next.jdbc "1.2.780"]
+                 [org.clojure/clojure "1.10.1"]
                  [org.clojure/java.jdbc "0.7.11"]
                  [org.clojure/tools.logging "1.1.0"]]
   :profiles {:dev {:dependencies [[jar-migrations "1.0.0"]
                                   [ch.qos.logback/logback-classic "1.2.3"]
                                   [com.h2database/h2 "1.4.200"]
-                                  [hikari-cp "2.13.0"]]}})
+                                  [hikari-cp/hikari-cp "2.13.0"] 
+                                  [org.clojure/tools.trace "0.7.11"]]}})

--- a/src/migratus/core.clj
+++ b/src/migratus/core.clj
@@ -68,7 +68,10 @@
   (let [completed? (set (proto/completed-ids store))]
     (filter (comp completed? proto/id) (mig/list-migrations config))))
 
-(defn uncompleted-migrations [config store]
+(defn uncompleted-migrations 
+  "Returns a list of uncompleted migrations.
+   Fetch list of applied migrations from db and existing migrations from migrations dir."
+  [config store]
   (let [completed? (set (proto/completed-ids store))]
     (remove (comp completed? proto/id) (mig/list-migrations config))))
 

--- a/test/migratus/test/database.clj
+++ b/test/migratus/test/database.clj
@@ -14,6 +14,7 @@
 (ns migratus.test.database
   (:require [clojure.java.io :as io]
             [clojure.java.jdbc :as sql]
+            [next.jdbc :as jdbc]
             [migratus.protocols :as proto]
             [migratus.core :as core]
             [clojure.test :refer :all]
@@ -22,7 +23,8 @@
             [migratus.test.migration.edn :as test-edn]
             [migratus.test.migration.sql :as test-sql]
             [migratus.utils :as utils]
-            [hikari-cp.core :as hk])
+            [hikari-cp.core :as hk]
+            [migratus.database :as db])
   (:import java.io.File
            java.util.jar.JarFile
            (java.util.concurrent CancellationException)))
@@ -200,6 +202,19 @@
   (is (not (test-sql/verify-table-exists? config "quux")))
   (is (not (test-sql/verify-table-exists? config "quux2"))))
 
+(comment
+  
+  (use 'clojure.tools.trace)
+  (trace-ns migratus.test.migration.sql)
+  (trace-ns migratus.test.database)
+  (trace-ns migratus.database)
+  (trace-ns migratus.protocols)
+  (trace-ns migratus.core)
+
+  (run-test test-rollback-until-just-after)
+  )
+
+
 (deftest test-migration-ignored-when-already-reserved
   (test-with-store
     (proto/make-store config)
@@ -223,6 +238,12 @@
         (mark-unreserved db migration-table-name)
         (core/down config 20111202110600)
         (is (not (test-sql/verify-table-exists? config "foo")))))))
+
+(comment 
+  
+(proto/make-store config)
+
+  )
 
 (defn copy-dir
   [^File from ^File to]
@@ -261,6 +282,11 @@
       (finally
         (utils/recursive-delete migration-dir)))))
 
+
+(comment 
+  
+  (run-test test-migration-ignored-when-already-reserved)
+  )
 
 
 (deftest test-description-and-applied-fields

--- a/test/migratus/test/migration/sql.clj
+++ b/test/migratus/test/migration/sql.clj
@@ -1,6 +1,5 @@
 (ns migratus.test.migration.sql
-  (:require [clojure.java.io :as io]
-            [clojure.java.jdbc :as sql]
+  (:require [clojure.java.io :as io] 
             [clojure.test :refer :all]
             [migratus.core :as core]
             [migratus.database :as db]
@@ -30,7 +29,7 @@
 (use-fixtures :each setup-test-db)
 
 (defn verify-table-exists? [config table-name]
-  (sql/with-db-connection [db (:db config)]
+  (let [db (:db config)]
     (db/table-exists? db table-name)))
 
 (deftest test-run-sql-migrations

--- a/test/migratus/test/migration/sql.clj
+++ b/test/migratus/test/migration/sql.clj
@@ -10,10 +10,10 @@
 
 (def db-store (str (.getName (io/file ".")) "/site.db"))
 
+
 (def test-config {:migration-dir        "migrations/"
-                  :db                   {:classname   "org.h2.Driver"
-                                         :subprotocol "h2"
-                                         :subname     db-store}})
+                  :db                   {:dbtype "h2" 
+                                         :dbname  db-store}})
 
 (defn reset-db []
   (letfn [(delete [f]

--- a/test/migratus/test/migrations.clj
+++ b/test/migratus/test/migrations.clj
@@ -31,10 +31,10 @@
   (is (number? (get (props/load-properties {:properties {}}) "${migratus.timestamp}")))
   (let [props (props/load-properties
                 {:properties
-                 {:env ["java.home"]
+                 {:env ["path"]
                   :map {:foo "bar"
                         :baz {:bar "foo"}}}})]
-    (is (seq (get props "${java.home}")))
+    (is (seq (get props "${path}")))
     (is (= "bar" (get props "${foo}")))
     (is (= "foo" (get props "${baz.bar}")))))
 


### PR DESCRIPTION
There are some differences in how java.jdbc works and how next.jdbc works and I don't know what is the best way to handle this in migratus.
migratus receives a db-spec and builds a connection that it uses as :connection . 
Most functions use this connection via this pattern:
```
 (sql/with-db-transaction [t-con db]
      (sql/db-do-commands
        t-con .... ) 
````

`java.jdbc` has a function `db-find-connection` that extracts the connection from the map. 
There is also logic to create a connection if one is not found. 

`next.jdbc` does not have this so I implemented:
```
(defn connection-or-spec
  "Migration code from java.jdbc to next.jdbc .
   java.jdbc accepts a spec that contains a ^java.sql.Connection as :connection.
   Return :connection or the db spec."
  [db]
  (let [conn (:connection db)]
    (if conn conn db)))
```


