### PR TITLE
181 fix connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ It is possible to pass a `java.sql.Connection` or `javax.sql.DataSource` in plac
                   {:dbtype "h2"
                    :dbname "site.db"}))
 
-(def config {:db connection})
+(def config {:db {:connection connection}})
 ```
 
 ```clojure
@@ -202,7 +202,7 @@ It is possible to pass a `java.sql.Connection` or `javax.sql.DataSource` in plac
 (def datasource-options {:adapter "h2"
                          :url     "jdbc:h2:./site.db"})
 
-(def config {:db (hk/make-datasource datasource-options)})
+(def config {:db {:datasource (hk/make-datasource datasource-options)}})
 ```
 
 #### Running as native image (Postgres only)

--- a/test/migratus/test/database.clj
+++ b/test/migratus/test/database.clj
@@ -61,7 +61,7 @@
   (testing "connect* works with a ^java.sql.Connection"
     (let [ds (jdbc/get-datasource db-mem)]
       (with-open [connection (jdbc/get-connection ds)]
-        (let [res (db/connect* connection)]
+        (let [res (db/connect* {:connection connection})]
           (is (map? res) "connect* response is a map")
           (is (contains? res :connection) "connect* response contains :connection")
           (is (instance? Connection (:connection res))
@@ -71,7 +71,7 @@
   
   (testing "connect* works with a ^javax.sql.DataSource"
     (let [ds (jdbc/get-datasource db-mem)
-          res (db/connect* ds)]
+          res (db/connect* {:datasource ds})]
       (is (map? res) "connect* response is a map")
       (is (contains? res :connection) "connect* response contains :connection")
       (is (instance? Connection (:connection res))
@@ -113,7 +113,7 @@
               (dissoc config :migration-table-name) default-migrations-table)))
     (test-with-store
      (proto/make-store (-> (dissoc config :migration-table-name)
-                           (assoc :db (jdbc/get-connection (:db config)))))
+                           (assoc :db {:connection (jdbc/get-connection (:db config))})))
      (fn [_]
        (test-sql/verify-table-exists? (dissoc config :migration-table-name)
                                       default-migrations-table))))

--- a/test/migratus/testcontainers/postgres.clj
+++ b/test/migratus/testcontainers/postgres.clj
@@ -36,12 +36,7 @@
                     :migration-dir "migrations-postgres"
                     :init-script "init.sql"
                     :migration-table-name "foo_bar"
-                    :db {:dbtype   "postgresql"
-                         :dbname   "postgres"
-                         :user     "postgres"
-                         :password "pw"
-                         :host     (:host initialized-pg-container)
-                         :port     (get (:mapped-ports initialized-pg-container) 5432)}}]
+                    :db {:datasource ds}}]
         (is (= [] (test-sql/db-tables-and-views ds)) "db is empty before migrations")
 
         ;; init 


### PR DESCRIPTION
* We can use :connection and :datasource again in migratus.
* For connection, it's closed after every step (init, migrate, rollback) so you need to pass a new connection for each step if your run them one after the other.
* Fix #181 