### PR TITLE
Specify up/down migrate functions with optional args

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,8 @@ Then, in `src/app/migrations/import_users.clj`:
   migrations can be configurable).
 - You can omit the up or down migration by setting `:up-fn` or
   `down-fn` to `nil` in the EDN file.
+- The migration functions can accept additional parameters by providing a vector of
+  args under keys `:up-args` and `:down-args`.
 
 ### Generate code-based migration files
 

--- a/README.md
+++ b/README.md
@@ -276,8 +276,9 @@ Then, in `src/app/migrations/import_users.clj`:
   migrations can be configurable).
 - You can omit the up or down migration by setting `:up-fn` or
   `down-fn` to `nil` in the EDN file.
-- The migration functions can accept additional parameters by providing a vector of
-  args under keys `:up-args` and `:down-args`.
+- The `:up-fn` and `:down-fn` entries can optionally be a vector containing the
+  migration function followed by additional args to be passed after
+  the config map, e.g. `{..., :up-fn [migrate-up "arg1" :arg2], ...}`.
 
 ### Generate code-based migration files
 

--- a/src/migratus/migration/edn.clj
+++ b/src/migratus/migration/edn.clj
@@ -41,9 +41,11 @@
 
 (defmethod proto/make-migration* :edn
   [_ mig-id mig-name payload config]
-  (let [{:keys [ns up-fn down-fn transaction? up-args down-args]
+  (let [{:keys [ns up-fn down-fn transaction?]
          :or   {up-fn "up" down-fn "down"}} (edn/read-string payload)
-        mig-ns (to-sym ns)]
+        mig-ns (to-sym ns)
+        [up-fn & up-args] (cond-> up-fn (not (coll? up-fn)) vector)
+        [down-fn & down-args] (cond-> down-fn (not (coll? down-fn)) vector)]
     (when-not mig-ns
       (throw (IllegalArgumentException.
                (format "Invalid migration %s: no namespace" mig-name))))
@@ -52,8 +54,8 @@
                     (resolve-fn mig-name mig-ns up-fn)
                     (resolve-fn mig-name mig-ns down-fn)
                     transaction?
-                    (or up-args [])
-                    (or down-args []))))
+                    up-args
+                    down-args)))
 
 (defmethod proto/get-extension* :edn
   [_]

--- a/test/migrations-edn-args/20220827210100-say-hello-with-args.edn
+++ b/test/migrations-edn-args/20220827210100-say-hello-with-args.edn
@@ -1,0 +1,6 @@
+{:ns migratus.test.migration.edn.test-script-args
+ :up-fn migrate-up
+ :up-args ["hello-with-args.txt" "Hello, world, with args!"]
+ :down-fn migrate-down
+ :down-args ["hello-with-args.txt"]
+ :transaction? true}

--- a/test/migrations-edn-args/20220827210100-say-hello-with-args.edn
+++ b/test/migrations-edn-args/20220827210100-say-hello-with-args.edn
@@ -1,6 +1,4 @@
 {:ns migratus.test.migration.edn.test-script-args
- :up-fn migrate-up
- :up-args ["hello-with-args.txt" "Hello, world, with args!"]
- :down-fn migrate-down
- :down-args ["hello-with-args.txt"]
+ :up-fn [migrate-up "hello-with-args.txt" "Hello, world, with args!"]
+ :down-fn [migrate-down "hello-with-args.txt"]
  :transaction? true}

--- a/test/migratus/test/migration/edn/test_script_args.clj
+++ b/test/migratus/test/migration/edn/test_script_args.clj
@@ -1,0 +1,11 @@
+(ns migratus.test.migration.edn.test-script-args
+  (:require [clojure.java.io :as io]))
+
+(defn migrate-up [{:keys [output-dir]} filename msg]
+  (.mkdirs (io/file output-dir))
+  (spit (io/file output-dir filename) msg))
+
+(defn migrate-down [{:keys [output-dir]} filename]
+  (let [f (io/file output-dir filename)]
+    (when (.exists f)
+      (.delete f))))

--- a/test/migratus/test/migration/edn_with_args.clj
+++ b/test/migratus/test/migration/edn_with_args.clj
@@ -1,0 +1,49 @@
+(ns migratus.test.migration.edn-with-args
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer :all]
+            [migratus.core :as core]
+            [migratus.migration.edn :refer :all]
+            migratus.mock
+            [migratus.protocols :as proto]
+            [migratus.utils :as utils])
+  (:import java.io.File))
+
+(defn unload [ns-sym]
+  (remove-ns ns-sym)
+  (dosync
+   (commute (deref #'clojure.core/*loaded-libs*) disj ns-sym)))
+
+(def test-namespace 'migratus.test.migration.edn.test-script-args)
+(def test-dir "target/edn-args-test")
+(def test-config {:output-dir test-dir})
+
+(defn test-file-exists? []
+  (let [f (io/file test-dir "hello-with-args.txt")]
+    (and (.exists f)
+         (= "Hello, world, with args!" (slurp f)))))
+
+(use-fixtures :once
+  (fn [f]
+    (f)
+    ;; `lein test` thinks it needs to test this namespace, so make sure
+    ;; that it exists when we're done
+    (require test-namespace)))
+
+(use-fixtures :each
+  (fn [f]
+    ;; unload the namespace before each test to ensure that it's loaded
+    ;; appropriately by the edn-migration code.
+    (unload test-namespace)
+    (utils/recursive-delete (io/file test-dir))
+    (f)))
+
+(deftest test-run-edn-migrations
+  (let [config (merge test-config
+                      {:store :mock
+                       :completed-ids (atom #{})
+                       :migration-dir "migrations-edn-args"})]
+    (is (not (test-file-exists?)))
+    (core/migrate config)
+    (is (test-file-exists?))
+    (core/rollback config)
+    (is (not (test-file-exists?)))))


### PR DESCRIPTION
The up/down migration function entries in a code-based migration file can optionally be a vector syntax, e.g. `{..., :up-fn [migrate-up "arg1" :arg2], ...}`, where the additional args will be passed to the migration function after the config map.