### PR TITLE
Remove sanitation of migration table name

### DIFF
--- a/src/migratus/database.clj
+++ b/src/migratus/database.clj
@@ -13,7 +13,6 @@
 ;;;; under the License.
 (ns migratus.database
   (:require [clojure.java.io :as io]
-            [clojure.string :as str]
             [clojure.tools.logging :as log]
             [migratus.migration.sql :as sql-mig]
             [migratus.properties :as props]
@@ -30,12 +29,9 @@
 (def default-migrations-table "schema_migrations")
 
 (defn migration-table-name
-  "Makes migration table name available from config.
-   Sanitizes the table name to avoid possible SQL injection."
+  "Makes migration table name available from config."
   [config]
-  (let [table-name (:migration-table-name config default-migrations-table)
-        sanitized (str/replace table-name #"\W" "")]
-    sanitized))
+  (:migration-table-name config default-migrations-table))
 
 (defn connection-or-spec
   "Migration code from java.jdbc to next.jdbc .

--- a/test/migratus/test/database.clj
+++ b/test/migratus/test/database.clj
@@ -105,7 +105,16 @@
     (test-with-store
       (proto/make-store config)
       (fn [config]
-        (is (test-sql/verify-table-exists? config "foo_bar"))))))
+        (is (test-sql/verify-table-exists? config "foo_bar")))))
+  (test-sql/reset-db)
+  (testing "should use complex table name"
+    (let [table-name "U&\"\\00d6ffnungszeit\""
+          config (assoc config :migration-table-name table-name)]
+      (is (not (test-sql/verify-table-exists? config table-name)))
+      (test-with-store
+        (proto/make-store config)
+        (fn [config]
+          (is (test-sql/verify-table-exists? config table-name)))))))
 
 (deftest test-make-store-pass-conn
   (testing "should create default table name"


### PR DESCRIPTION
Added in #214, the change to `migratus.database/migration-table-name` attempted to prevent SQL injections. However, the change was both over-broad (as most SQL engines allow for qualified or quoted identifiers) and not the correct place to guard against such attacks (as anyone running a migration could just write malicious SQL directly in a new migration file).

The change is reverted to its previous implementation.

Fixes #230