### PR TITLE
Fix error if any migration lacked an applied date

### DIFF
--- a/src/migratus/database.clj
+++ b/src/migratus/database.clj
@@ -169,7 +169,7 @@
     (->> (sql/query t-con
                     [(str "select id, applied from " table-name " where id != " reserved-id)]
                     {:builder-fn rs/as-unqualified-lower-maps})
-         (sort-by :applied #(.compareTo %2 %1))
+         (sort-by :applied #(compare %2 %1))
          (map :id)
          (doall))))
 


### PR DESCRIPTION
The sort on `:applied` in `migratus.database/completed-ids*` did not handle nil, meaning the presence of one or more migrations lacking an `applied` timestamp would cause it to break. Any sql migrations pre-0.9.1 will not have an `applied` value unless users have retroactively set it, and the schema allows NULLs, so migratus cannot assume `applied` is not nil.

The fix is simple because we have `compare`, which is essentially `.compareTo`-but-handles-nil. Any nil values will be sorted to the end, which is correct for the intended purpose here.

Current tests wouldn't catch this because they migrate up a database from scratch without legacy records. I have looked for a relevant test to update/add, but there's no integration test with an existing migrations table and it seems like a bunch of work to add one. 