### PR TITLE
Allow calling code to manage connection disconnects

### DIFF
--- a/src/migratus/database.clj
+++ b/src/migratus/database.clj
@@ -297,7 +297,7 @@
                   (get config :init-in-transaction? true)
                   (props/load-properties config))
         (finally
-          (disconnect* conn)))))
+          (proto/disconnect this)))))
   (completed-ids [this]
     (completed-ids* @connection (migration-table-name config)))
   (completed [this]
@@ -322,7 +322,8 @@
                   (migration-table-name config)
                   (sql-mig/wrap-modify-sql-fn (:modify-sql-fn config))))
   (disconnect [this]
-    (disconnect* @connection)
+    (when-not (:managed-connection? (:db config))
+      (disconnect* @connection))
     (reset! connection nil)))
 
 (defmethod proto/make-store :database

--- a/test/migratus/test/database.clj
+++ b/test/migratus/test/database.clj
@@ -401,16 +401,15 @@
     (is (not (test-sql/verify-table-exists? test-config "foo")))))
 
 (deftest test-no-tx-migration-pass-conn
-  (with-open [assertions-conn (jdbc/get-connection (:db config))]
-    (let [assertions-config (assoc config
+  (with-open [conn (jdbc/get-connection (:db config))]
+    (let [test-config (assoc config
                                    :migration-dir "migrations-no-tx"
-                                   :db {:connection assertions-conn})
-          test-config #(assoc assertions-config :db {:connection (jdbc/get-connection (:db config))})]
-      (is (not (test-sql/verify-table-exists? assertions-config "foo")))
-      (core/migrate (test-config))
-      (is (test-sql/verify-table-exists? assertions-config "foo"))
-      (core/down (test-config) 20111202110600)
-      (is (not (test-sql/verify-table-exists? assertions-config "foo"))))))
+                                   :db {:connection conn :managed-connection? true})]
+      (is (not (test-sql/verify-table-exists? test-config "foo")))
+      (core/migrate test-config)
+      (is (test-sql/verify-table-exists? test-config "foo"))
+      (core/down test-config 20111202110600)
+      (is (not (test-sql/verify-table-exists? test-config "foo"))))))
 
 (deftest test-cancellation-observed
   (let [lines-processed (atom 0)


### PR DESCRIPTION
Resolves #255 

The current implementation in this branch is not exactly what was discussed in #255. I got more familiar with the code and wanted to put something out there and discuss further.

The change in this branch appears to be the one that requires the fewest changes. The `Database` record now does not call `disconnect*` if `:managed-connection?` is set on the `:db` config.

---

Alternative that was discussed in #255 was to create a new implementation of `Store`. This would require:

1. Adding a new method for `proto/make-store` that I guess would check for the `:store` to be `:managed-database`, example config:
  ```clojure
  {:store :managed-database                                   
   :properties {:env ["database.table"]               
                :map {:database {:user "bob"}}}       
   :db {:connection ...}}                         
  ```
  (I haven't looked through all of the code to see what else might need to change to handle a new `:store` key.)
2. Most of the functionality inside the `Database` record would need to factored out into standalone functions that both `Database` and the new `ManagedDatabase` could call.

---

A second alternative that I thought of would be to introduce either a protocol or a multimethod that is used by the `disconnect*` function (and perhaps for consistency, `connect*` as well). 

I'm currently leaning towards doing this, since it will mean the `disconnect*` function will be safe to use in the future, without the calling code needing to worry about whether the disconnect should really happen.