### PR TITLE
Fix spec problem for next.jdbc.sql/insert! and next.jdbc.sql/delete!

### DIFF
--- a/src/migratus/database.clj
+++ b/src/migratus/database.clj
@@ -46,11 +46,12 @@
 (defn mark-reserved [db table-name]
   (boolean
     (try
-      (sql/insert! (connection-or-spec db) table-name  {:id reserved-id} {:return-keys false})
-      (catch Exception _e))))
+      (sql/insert! (connection-or-spec db) (keyword table-name) {:id reserved-id} {:return-keys false})
+      (catch Exception e
+        (log/infof "mark-reserved failed %s" (ex-message e))))))
 
 (defn mark-unreserved [db table-name]
-  (sql/delete! (connection-or-spec db) table-name ["id=?" reserved-id]))
+  (sql/delete! (connection-or-spec db) (keyword table-name) ["id=?" reserved-id]))
 
 (defn complete? [db table-name id]
   (first (sql/query (connection-or-spec db)
@@ -59,9 +60,10 @@
 (defn mark-complete [db table-name description id]
   (log/debug "marking" id "complete")
   (sql/insert! (connection-or-spec db)
-               table-name {:id          id
-                           :applied     (java.sql.Timestamp. (.getTime (java.util.Date.)))
-                           :description description}))
+               (keyword table-name)
+               {:id          id
+                :applied     (java.sql.Timestamp. (.getTime (java.util.Date.)))
+                :description description}))
 
 (defn mark-not-complete [db table-name id]
   (log/debug "marking" id "not complete")


### PR DESCRIPTION
When in dev mode, where I run `clojure.spec.test.alpha/instrument`, migrations would not run saying `Migration reserved by another instance. Ignoring.` It turns out there's a spec problem calling `insert!` and `delete!` with `table-name` as a `string`. Although a `string` works perfectly if you just don't spec check it.

**Note** And don't silently ignore `mark-reserved` errors