### PR TITLE
Fix bug in sanitizing in-line comments

### DIFF
--- a/src/migratus/migration/sql.clj
+++ b/src/migratus/migration/sql.clj
@@ -10,8 +10,8 @@
     java.util.regex.Pattern))
 
 (def ^Pattern sep (Pattern/compile "^.*--;;.*\r?\n" Pattern/MULTILINE))
-(def ^Pattern sql-comment (Pattern/compile "^--.*" Pattern/MULTILINE))
-(def ^Pattern sql-comment-without-expect (Pattern/compile "^--((?! *expect).)*$" Pattern/MULTILINE))
+(def ^Pattern sql-comment (Pattern/compile "--.*" Pattern/MULTILINE))
+(def ^Pattern sql-comment-without-expect (Pattern/compile "--((?! *expect).)*$" Pattern/MULTILINE))
 (def ^Pattern empty-line (Pattern/compile "^[ ]+" Pattern/MULTILINE))
 
 (defn use-tx? [sql]

--- a/test/migrations-parse/20241012170200-create-quux-table.down.sql
+++ b/test/migrations-parse/20241012170200-create-quux-table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE quux;

--- a/test/migrations-parse/20241012170200-create-quux-table.up.sql
+++ b/test/migrations-parse/20241012170200-create-quux-table.up.sql
@@ -1,0 +1,6 @@
+-- test comment parsed correctly
+CREATE TABLE -- first comment
+quux -- second comment;
+(id bigint,
+ name varchar(255)); -- last comment
+-- end

--- a/test/migratus/test/database.clj
+++ b/test/migratus/test/database.clj
@@ -391,6 +391,12 @@
   (log/debug "running backout tests without tx")
   (test-backing-out* (assoc config :migration-dir "migrations-intentionally-broken-no-tx")))
 
+(deftest test-comment-parsing-in-migration
+  (log/debug "running comment parsing test")
+  (is (not (test-sql/verify-table-exists? config "quux")))
+  (core/migrate (assoc config :migration-dir "migrations-parse"))
+  (is (test-sql/verify-table-exists? config "quux"))
+  (core/down config 20241012170200))
 
 (deftest test-no-tx-migration
   (let [{:keys [db migration-table-name] :as test-config} (assoc config :migration-dir "migrations-no-tx")]


### PR DESCRIPTION
probably related issue #208 

I identified an issue where an error occurs when trying to migrate a SQL script that contains comments in the middle of the statement. For example, the following script would result in an error:

```
CREATE TABLE -- first comment
quux -- second comment;
(id bigint,
 name varchar(255));
```

Although it’s unclear whether this behavior is intentional, there appears to be a bug in the pattern used to sanitize comments. I have made the necessary adjustments to resolve this issue.
