### PR TITLE
Warn on multiple statements without delimiter

### DIFF
--- a/src/migratus/migration/sql.clj
+++ b/src/migratus/migration/sql.clj
@@ -51,7 +51,7 @@
 
 (defn parse-commands-sql [{:keys [command-separator]} commands]
   (when (and (nil? command-separator) (> (count (re-seq #"(?m).+?;" commands)) 1))
-    (log/error "Mismatch between number of SQL statements and '--;;' separators. Please ensure each statement is separated by '--;;'."))
+    (log/warn "Mismatch between number of SQL statements and '--;;' separators. Please ensure each statement is separated by '--;;'."))
   (if command-separator
     (->>
       (str/split commands (re-pattern command-separator))

--- a/src/migratus/migration/sql.clj
+++ b/src/migratus/migration/sql.clj
@@ -50,6 +50,8 @@
         result))))
 
 (defn parse-commands-sql [{:keys [command-separator]} commands]
+  (when (and (nil? command-separator) (> (count (re-seq #"(?m).+?;" commands)) 1))
+    (log/error "Mismatch between number of SQL statements and '--;;' separators. Please ensure each statement is separated by '--;;'."))
   (if command-separator
     (->>
       (str/split commands (re-pattern command-separator))


### PR DESCRIPTION
solves #258 

### Why:

If users are unaware that SQL statements are split by the default `--;;` delimiter, it could lead to errors during parsing. This PR adds a warning log to alert users when multiple SQL statements are detected without the use of the correct command-separator. The warning ensures that users are aware of the default separator and can properly structure their SQL commands to avoid parsing issues.

### Description:

The SQL input is split by the default separator `--;;`. Each command is parsed by `parse-commands-sql` based on the command-separator. When the `command-separator` is specified, the command is split into a sequence. If no `command-separator` is specified, the command is not parsed.

In cases where no command-separator is specified and the command contains more than one semicolon, it is considered to contain multiple SQL statements. A warning will now be issued in such cases to inform the user of the potential issue.
