### PR TITLE
Add functionality for squashing migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,9 +395,10 @@ This is intended for use with http://2ndquadrant.com/en/resources/pglogical/ and
    | `migratus.core/reset`                 | Reset the database by down-ing all migrations successfully applied, then up-ing all migratinos.
    | `migratus.core/pending-list`              | Returns a list of pending migrations.                                                                                                              |
    | `migratus.core/migrate-until-just-before` | Run `up` for for any pending migrations which precede the given migration id (good for testing migrations).                                        |
-   | `migratus.core/squashing-list`            | List migrations to be squashed between the given migration ids.
-   | `migratus.core/create-squash`             | Create a new squash migration file between the given migration ids.
-   | `migratus.core/squash-between`            | Apply squashed migrations between(both inclusive) the given migration ids.
+   | `migratus.core/squashing-list`            | Takes from-id and to-id as inputs (both inclusive) and returns the list of migrations to be squashed. 
+   | `migratus.core/create-squash`             | Reads files within the specified id range and generates a new squashed migration file. It removes the original migration files and creates a new one with the last ID from the range and a user-provided name.
+   | `migratus.core/squash-between`           | Updates the migration table by marking the old IDs as squashed and replacing them with the new ID. No actual migration is applied, assuming they were previously applied.
+
 See the docstrings of each function for more details.
 
 Migratus can also be used from leiningen if you add it as a plugin dependency.

--- a/README.md
+++ b/README.md
@@ -395,7 +395,9 @@ This is intended for use with http://2ndquadrant.com/en/resources/pglogical/ and
    | `migratus.core/reset`                 | Reset the database by down-ing all migrations successfully applied, then up-ing all migratinos.
    | `migratus.core/pending-list`              | Returns a list of pending migrations.                                                                                                              |
    | `migratus.core/migrate-until-just-before` | Run `up` for for any pending migrations which precede the given migration id (good for testing migrations).                                        |
-
+   | `migratus.core/squashing-list`            | List migrations to be squashed between the given migration ids.
+   | `migratus.core/create-squash`             | Create a new squash migration file between the given migration ids.
+   | `migratus.core/squash-between`            | Apply squashed migrations between(both inclusive) the given migration ids.
 See the docstrings of each function for more details.
 
 Migratus can also be used from leiningen if you add it as a plugin dependency.

--- a/src/migratus/core.clj
+++ b/src/migratus/core.clj
@@ -215,20 +215,18 @@
 (defn create-squash
   "Delete all migrations between from and to,
    squash them into a single migration with the given name and last applied migration date."
-  [config & [name from-id to-id]]
+  [config & [from-id to-id name]]
   (let [migrations (migrations-between config from-id to-id)
         ups (str/join "\n--;;\n" (map :up migrations))
         downs (str/join "\n--;;\n" (reverse (map :down migrations)))
-        last-id (:id (last migrations))]
+        id (:id (last migrations))]
     (when (not (every? #(= (:mig-type %) :sql) migrations))
       (throw (IllegalArgumentException. "All migrations must be of the same type.")))
     (doseq [migration migrations]
       (when (not (:applied migration))
-        (throw (IllegalArgumentException. (str "Migration " (:id migration) " is not applied. Apply it first.")))))
-    (doseq [migration migrations]
+        (throw (IllegalArgumentException. (str "Migration " (:id migration) " is not applied. Apply it first."))))
       (mig/destroy config (:name migration)))
-    (mig/create-squash config last-id name :sql ups downs)))
-
+    (mig/create-squash config id name :sql ups downs)))
 
 (defn destroy
   "Destroy migration"

--- a/src/migratus/core.clj
+++ b/src/migratus/core.clj
@@ -270,6 +270,17 @@
         (throw (IllegalArgumentException. (str "Migration " (:id migration) " is not applied. Apply it first.")))))
     (mapv :name migrations)))
 
+(defn squash-between
+    "Squash a batch of migrations into a single migration"
+    [config from-id to-id name]
+  (with-store [store (proto/make-store config)]
+    (let [completed-ids (->> (proto/completed-ids store)
+                             (filter (fn [mig-id]
+                                       (and (>= mig-id from-id)
+                                            (<= mig-id to-id)))))]
+      (log/debug (apply str "You have " (count completed-ids) " migrations to be squashed:\n"
+                        (str/join "\n" completed-ids)))
+      (proto/squash store completed-ids name))))
 
 (defn migrate-until-just-before
   "Run all migrations preceding migration-id. This is useful when testing that a

--- a/src/migratus/core.clj
+++ b/src/migratus/core.clj
@@ -275,7 +275,8 @@
     (let [completed-ids (->> (proto/completed-ids store)
                              (filter (fn [mig-id]
                                        (and (>= mig-id from-id)
-                                            (<= mig-id to-id)))))]
+                                            (<= mig-id to-id))))
+                             (sort >))]
       (log/debug (apply str "You have " (count completed-ids) " migrations to be squashed:\n"
                         (str/join "\n" completed-ids)))
       (proto/squash store completed-ids name))))

--- a/src/migratus/core.clj
+++ b/src/migratus/core.clj
@@ -261,6 +261,8 @@
     (doseq [migration migrations]
       (when (not (:applied migration))
         (throw (IllegalArgumentException. (str "Migration " (:id migration) " is not applied. Apply it first.")))))
+    (doseq [migration migrations]
+      (mig/destroy config (:name migration)))
     (mig/squash config last-id name :sql ups downs)))
 
 (defn migrate-until-just-before

--- a/src/migratus/core.clj
+++ b/src/migratus/core.clj
@@ -90,6 +90,18 @@
          (gather-migrations config)
          (map (fn [e] {:id (:id e) :name (:name e) :applied (:applied e)})))))
 
+(defn migrations-between 
+  "Returns a list of migrations between from(inclusive) and to(inclusive)."
+  [config from to]
+  (with-store
+    [store (proto/make-store config)]
+    (->> store
+         (gather-migrations config)
+         (filter (fn [e]
+                   (and (>= (:id e) from)
+                        (<= (:id e) to))))
+         (sort-by :id))))
+
 (defn uncompleted-migrations
   "Returns a list of uncompleted migrations.
    Fetch list of applied migrations from db and existing migrations from migrations dir."
@@ -226,6 +238,7 @@
     (log/debug (apply str "You have " (count migrations) " pending migrations:\n"
                       (str/join "\n" migrations)))
     (mapv second migrations)))
+
 
 (defn migrate-until-just-before
   "Run all migrations preceding migration-id. This is useful when testing that a

--- a/src/migratus/database.clj
+++ b/src/migratus/database.clj
@@ -127,7 +127,7 @@
       (try
         (when (complete-all? db table-name ids)
           (mark-not-complete-all db table-name ids)
-          (mark-complete db table-name name (last ids)) 
+          (mark-complete db table-name name (first ids)) 
           :success)
         (finally
           (mark-unreserved db table-name)))

--- a/src/migratus/database.clj
+++ b/src/migratus/database.clj
@@ -14,6 +14,7 @@
 (ns migratus.database
   (:require [clojure.java.io :as io]
             [clojure.tools.logging :as log]
+            [clojure.string :as str]
             [migratus.migration.sql :as sql-mig]
             [migratus.properties :as props]
             [migratus.protocols :as proto]
@@ -57,6 +58,14 @@
   (first (sql/query (connection-or-spec db)
                     [(str "SELECT * from " table-name " WHERE id=?") id])))
 
+(defn complete-all? [db table-name ids]
+  (when (seq ids)
+    (not-empty
+     (sql/query (connection-or-spec db)
+                  [(str "SELECT * FROM " table-name " WHERE id IN ("
+                        (str/join "," ids)
+                        ")")]))))
+
 (defn mark-complete [db table-name description id]
   (log/debug "marking" id "complete")
   (sql/insert! (connection-or-spec db)
@@ -68,6 +77,13 @@
 (defn mark-not-complete [db table-name id]
   (log/debug "marking" id "not complete")
   (sql/delete! (connection-or-spec db) table-name ["id=?" id]))
+
+(defn mark-not-complete-all [db table-name ids]
+  (log/debug "marking" ids "not complete")
+  (when (seq ids)
+    (jdbc/execute! db [(str "DELETE FROM " table-name " WHERE id IN ("
+                           (str/join "," ids)
+                           ")")])))
 
 (defn migrate-up* [db {:keys [tx-handles-ddl?] :as config} {:keys [name] :as migration}]
   (let [id         (proto/id migration)
@@ -100,6 +116,18 @@
         (when (complete? db table-name id)
           (proto/down migration (assoc config :conn db))
           (mark-not-complete db table-name id)
+          :success)
+        (finally
+          (mark-unreserved db table-name)))
+      :ignore)))
+
+(defn squash* [db config ids name]
+  (let [table-name (migration-table-name config)]
+    (if (mark-reserved db table-name)
+      (try
+        (when (complete-all? db table-name ids)
+          (mark-not-complete-all db table-name ids)
+          (mark-complete db table-name name (last ids)) 
           :success)
         (finally
           (mark-unreserved db table-name)))
@@ -318,6 +346,11 @@
                   (jdbc/with-transaction [t-con (connection-or-spec @connection)]
                     (migrate-down* t-con config migration))
                   (migrate-down* (:db config) config migration)))
+  (squash [this ids name]
+          (log/info "Connection is " @connection
+                    "Config is" (update config :db utils/censor-password))
+          (jdbc/with-transaction [t-con (connection-or-spec @connection)]
+            (squash* t-con config ids name)))
   (connect [this]
     (reset! connection (connect* (:db config)))
     (init-schema! @connection

--- a/src/migratus/migration/edn.clj
+++ b/src/migratus/migration/edn.clj
@@ -11,7 +11,7 @@
   (id [this] id)
   (migration-type [this] :edn)
   (name [this] name)
-  (tx? [this direction] (if (nil? transaction?) true transaction?)) 
+  (tx? [this direction] (if (nil? transaction?) true transaction?))
   (up [this config]
     (when up-fn
       (apply up-fn config up-args)))

--- a/src/migratus/migration/edn.clj
+++ b/src/migratus/migration/edn.clj
@@ -64,3 +64,7 @@
 (defmethod proto/migration-files* :edn
   [x migration-name]
   [(str migration-name "." (proto/get-extension* x))])
+
+(defmethod proto/squash-migration-files* :edn
+  [x migration-dir migration-name ups downs]
+  (throw (Exception. "EDN migrations not implemented")))

--- a/src/migratus/migration/edn.clj
+++ b/src/migratus/migration/edn.clj
@@ -9,8 +9,9 @@
 (defrecord EdnMigration [id name up-fn down-fn transaction? up-args down-args]
   proto/Migration
   (id [this] id)
+  (migration-type [this] :edn)
   (name [this] name)
-  (tx? [this direction] (if (nil? transaction?) true transaction?))
+  (tx? [this direction] (if (nil? transaction?) true transaction?)) 
   (up [this config]
     (when up-fn
       (apply up-fn config up-args)))

--- a/src/migratus/migration/sql.clj
+++ b/src/migratus/migration/sql.clj
@@ -112,6 +112,7 @@
   proto/Migration
   (id [this]
     id)
+  (migration-type [this] :sql)
   (name [this]
     name)
   (tx? [this direction]

--- a/src/migratus/migration/sql.clj
+++ b/src/migratus/migration/sql.clj
@@ -3,7 +3,8 @@
             [next.jdbc.prepare :as prepare]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
-            [migratus.protocols :as proto])
+            [migratus.protocols :as proto]
+            [clojure.java.io :as io])
   (:import
     (java.sql Connection
               SQLException)
@@ -140,3 +141,13 @@
   (let [ext (proto/get-extension* x)]
     [(str migration-name ".up." ext)
      (str migration-name ".down." ext)]))
+
+(defmethod proto/squash-migration-files* :sql
+  [x migration-dir migration-name ups downs]
+  (doall
+   (for [[mig-file sql] (map vector (proto/migration-files* x migration-name) [ups downs])]
+     (let [file (io/file migration-dir mig-file)]
+       (.createNewFile file)
+       (with-open [writer (java.io.BufferedWriter. (java.io.FileWriter. file))]
+         (.write writer sql))
+       (.getName (io/file migration-dir mig-file))))))

--- a/src/migratus/migrations.clj
+++ b/src/migratus/migrations.clj
@@ -169,12 +169,11 @@
          (.createNewFile file)
          (.getName (io/file migration-dir mig-file)))))))
 
-(defn squash [config last-id name migration-type ups downs]
-  ;; FIXME: only support sql migrations for now
+(defn create-squash [config id name migration-type ups downs]
   (let [migration-dir  (find-or-create-migration-dir
                         (utils/get-parent-migration-dir config)
                         (utils/get-migration-dir config))
-        migration-name (->kebab-case (str last-id "-" name))]
+        migration-name (->kebab-case (str id "-" name))]
     (proto/squash-migration-files* migration-type migration-dir migration-name ups downs)))
 
 (defn destroy [config name]

--- a/src/migratus/migrations.clj
+++ b/src/migratus/migrations.clj
@@ -175,14 +175,7 @@
                         (utils/get-parent-migration-dir config)
                         (utils/get-migration-dir config))
         migration-name (->kebab-case (str last-id "-" name))]
-    (doall
-     (for [[mig-file sql] (map vector (proto/migration-files* migration-type migration-name) [ups downs])]
-       (let [file (io/file migration-dir mig-file)]
-         (.createNewFile file)
-         (with-open [writer (java.io.BufferedWriter. (java.io.FileWriter. file))]
-           (.write writer sql))
-         (.getName (io/file migration-dir mig-file)))))))
-
+    (proto/squash-migration-files* migration-type migration-dir migration-name ups downs)))
 
 (defn destroy [config name]
   (let [migration-dir  (utils/find-migration-dir

--- a/src/migratus/protocols.clj
+++ b/src/migratus/protocols.clj
@@ -16,6 +16,7 @@
 
 (defprotocol Migration
   (id [this] "Id of this migration.")
+  (migration-type [this] "Type of this migration.")
   (name [this] "Name of this migration")
   (tx? [this direction] "Whether this migration should run in a transaction.")
   (up [this config] "Bring this migration up.")

--- a/src/migratus/protocols.clj
+++ b/src/migratus/protocols.clj
@@ -36,6 +36,8 @@
     "Run and record an up migration")
   (migrate-down [this migration]
     "Run and record a down migration")
+  (squash [this migrations]
+    "Squash a batch of migrations into a single migration")
   (connect [this]
     "Opens resources necessary to run migrations against the store.")
   (disconnect [this]

--- a/src/migratus/protocols.clj
+++ b/src/migratus/protocols.clj
@@ -81,3 +81,13 @@
   (for [[k v] (methods get-extension*)
         :when (-> k (= :default) not)]
     (v k)))
+
+(defmulti squash-migration-files*
+  "Dispatcher to read a list of files and squash them into a single migration"
+  (fn [mig-type migration-dir migration-name ups downs]
+    mig-type))
+
+(defmethod squash-migration-files* :default
+  [mig-type migration-dir migration-name ups downs]
+  (throw (Exception. (format "Unknown migration type '%s'"
+                             (clojure.core/name mig-type)))))

--- a/src/migratus/protocols.clj
+++ b/src/migratus/protocols.clj
@@ -36,7 +36,7 @@
     "Run and record an up migration")
   (migrate-down [this migration]
     "Run and record a down migration")
-  (squash [this migrations]
+  (squash [this ids name]
     "Squash a batch of migrations into a single migration")
   (connect [this]
     "Opens resources necessary to run migrations against the store.")
@@ -86,7 +86,7 @@
     (v k)))
 
 (defmulti squash-migration-files*
-  "Dispatcher to read a list of files and squash them into a single migration"
+  "Dispatcher to read a list of files and squash them into a single migration file"
   (fn [mig-type migration-dir migration-name ups downs]
     mig-type))
 

--- a/test/migratus/mock.clj
+++ b/test/migratus/mock.clj
@@ -18,6 +18,8 @@
   proto/Migration
   (id [this]
     id)
+  (migration-type [this]
+    :sql)
   (name [this]
     name)
   (up [this config]

--- a/test/migratus/mock.clj
+++ b/test/migratus/mock.clj
@@ -32,6 +32,8 @@
   (init [this])
   (completed-ids [this]
     @completed-ids)
+  (completed [this]
+    (map (fn [id] {:id id :applied true}) @completed-ids))
   (migrate-up [this migration]
     (proto/up migration config)
     (swap! completed-ids conj (proto/id migration))

--- a/test/migratus/test/core.clj
+++ b/test/migratus/test/core.clj
@@ -144,6 +144,23 @@
         (is (= ["id-2" "id-3" "id-4"]
                (migratus.core/pending-list config)))))))
 
+(deftest test-squashing-list
+  (let [ups    (atom [])
+        downs  (atom [])
+        config {:store         :mock
+                :completed-ids (atom #{1 3})}]
+    (with-redefs [mig/list-migrations (constantly (migrations ups downs))]
+      (testing "should throw an exception if the migration is not applied"
+        (is (thrown? IllegalArgumentException
+               (migratus.core/squashing-list config 1 3))))
+      (testing "should bring up an uncompleted migration"
+        (up config 4 2)
+        (is (= [2 4] @ups))
+        (is (empty? @downs)))
+      (testing "should return the list of squashing migrations"
+        (is (= ["id-1" "id-3" "id-2"]
+               (migratus.core/squashing-list config 1 3)))))))
+
 (deftest test-select-migrations
   (let [ups    (atom [])
         downs  (atom [])

--- a/test/migratus/test/core.clj
+++ b/test/migratus/test/core.clj
@@ -152,13 +152,16 @@
     (with-redefs [mig/list-migrations (constantly (migrations ups downs))]
       (testing "should throw an exception if the migration is not applied"
         (is (thrown? IllegalArgumentException
-               (migratus.core/squashing-list config 1 3))))
+                     (migratus.core/squashing-list config 1 3))))
       (testing "should bring up an uncompleted migration"
         (up config 4 2)
         (is (= [2 4] @ups))
         (is (empty? @downs)))
-      (testing "should return the list of squashing migrations"
-        (is (= ["id-1" "id-3" "id-2"]
+      (testing "should return the list of squashing migrations in order"
+        (is (= ["id-1" "id-2" "id-3" "id-4"]
+               (migratus.core/squashing-list config 1 4))))
+      (testing "should return the list of squashing migrations within the inclusive range"
+        (is (= ["id-1" "id-2" "id-3"]
                (migratus.core/squashing-list config 1 3)))))))
 
 (deftest test-select-migrations

--- a/test/migratus/test/database.clj
+++ b/test/migratus/test/database.clj
@@ -362,23 +362,19 @@
                        :migration-dir "migrations-squash"})]
     (try
       (utils/recursive-delete migration-dir)
-      (copy-dir (io/file "test/migrations") migration-dir)
+      (copy-dir (io/file "test/migrations1") migration-dir)
       (core/migrate config)
-      (core/create-squash config "test-squash" 20111202110600 20241202113000)
-      (is (test-sql/verify-table-exists? config "foo"))
-      (is (test-sql/verify-table-exists? config "bar"))
-      (is (test-sql/verify-table-exists? config "quux"))
-      (is (test-sql/verify-table-exists? config "quux2"))
-      (is (.exists (io/file (str migration-dir "/20120827170200-test-squash.up.sql"))))
-      (is (.exists (io/file (str migration-dir "/20120827170200-test-squash.down.sql"))))
+      (core/create-squash config 20111202110600 20241202113000 "test-squash")
+      (is (test-sql/verify-table-exists? config "foo1"))
+      (is (test-sql/verify-table-exists? config "bar1"))
+      (is (.exists (io/file (str migration-dir "/20220604113000-test-squash.up.sql"))))
+      (is (.exists (io/file (str migration-dir "/20220604113000-test-squash.down.sql"))))
       (core/squash-between config 20111202110600 20241202113000 "test-squash")
-      (is (test-sql/verify-table-exists? config "foo"))
-      (is (test-sql/verify-table-exists? config "bar"))
-      (is (test-sql/verify-table-exists? config "quux"))
-      (is (test-sql/verify-table-exists? config "quux2"))
+      (is (test-sql/verify-table-exists? config "foo1"))
+      (is (test-sql/verify-table-exists? config "bar1"))
       (let [from-db (verify-data config (:migration-table-name config))]
         (is (= (map #(dissoc % :applied) from-db)
-               '({:id          20120827170200,
+               '({:id          20220604113000,
                   :description "test-squash"}))))
       (finally
         (utils/recursive-delete migration-dir)))))

--- a/test/migratus/test/database.clj
+++ b/test/migratus/test/database.clj
@@ -245,6 +245,14 @@
   (is (not (test-sql/verify-table-exists? config "quux")))
   (is (not (test-sql/verify-table-exists? config "quux2"))))
 
+(deftest test-squash
+  (core/migrate config)
+  (core/squash-between config "test-squash" 20111202110600 20120827170200)
+  (is (test-sql/verify-table-exists? config "foo"))
+  (is (test-sql/verify-table-exists? config "bar"))
+  (is (test-sql/verify-table-exists? config "quux"))
+  (is (test-sql/verify-table-exists? config "quux2")))
+
 (comment
 
   (use 'clojure.tools.trace)
@@ -259,6 +267,7 @@
   (trace-ns next.jdbc.protocols)
 
   (run-test test-rollback-until-just-after)
+  (run-test test-squash)
 
   (core/migrate config)
   (db/mark-unreserved (:db config) "foo_bar")


### PR DESCRIPTION
resolves #263 

### Why?

Over time, projects can accumulate numerous migrations, making them harder to manage and potentially slowing down the migration process. By squashing older migrations into a single file, the migration process becomes more streamlined and manageable.
This PR introduces three core function for squashing multiple migrations into a single migration file, which simplifies the management of large migration histories.

### Core Functions
- squashing-list: Takes from-id and to-id as inputs (both inclusive) and returns the list of migrations to be squashed.
- create-squash: Reads files within the specified id range and generates a new squashed migration file. It removes the original migration files and creates a new one with the last ID from the range and a user-provided name.
- squash: Updates the migration table by marking the old IDs as squashed and replacing them with the new ID. No actual migration is applied, assuming they were previously applied.

The squashing process is broken down into three distinct steps to reduce the risk of human errors, to preview before applying changes.

### Validations
- Mixed migration formats (EDN and SQL) are not supported: If there is a mix of EDN (code-based) and SQL (SQL-based) migrations in the specified range, an exception is thrown.
- EDN migration squashing is not implemented yet, and this functionality has been added to the backlog for future development.
- If there are unapplied migrations, an exception will be raised to prevent squashing incomplete migrations, ensuring database consistency.
