### PR TITLE
Fix mark-not-complete to pass keyword table name (#279)

### DIFF
--- a/src/migratus/database.clj
+++ b/src/migratus/database.clj
@@ -76,7 +76,7 @@
 
 (defn mark-not-complete [db table-name id]
   (log/debug "marking" id "not complete")
-  (sql/delete! (connection-or-spec db) table-name ["id=?" id]))
+  (sql/delete! (connection-or-spec db) (keyword table-name) ["id=?" id]))
 
 (defn mark-not-complete-all [db table-name ids]
   (log/debug "marking" ids "not complete")

--- a/test/migratus/test/database.clj
+++ b/test/migratus/test/database.clj
@@ -245,6 +245,20 @@
   (is (not (test-sql/verify-table-exists? config "quux")))
   (is (not (test-sql/verify-table-exists? config "quux2"))))
 
+(deftest test-mark-not-complete-conforms-to-jdbc-spec
+  (testing "mark-not-complete should pass a keyword table-name to next.jdbc.sql/delete! (issue #279)"
+    (require 'next.jdbc.specs)
+    (let [instrument!   (resolve 'next.jdbc.specs/instrument)
+          unstrument!   (resolve 'next.jdbc.specs/unstrument)]
+      (try
+        (instrument!)
+        (core/migrate config)
+        (is (test-sql/verify-table-exists? config "bar"))
+        (core/down config 20111202113000)
+        (is (not (test-sql/verify-table-exists? config "bar")))
+        (finally
+          (unstrument!))))))
+
 
 (comment
 


### PR DESCRIPTION
## Summary
- Fixes #279 — `migratus.database/mark-not-complete` was passing a string `table-name` to `next.jdbc.sql/delete!`, which specs the table as a keyword. Under spec instrumentation this raised a `did not conform to spec` exception during rollbacks.
- Wraps `table-name` in `(keyword …)` to match the existing `mark-unreserved` / `mark-complete` callers.
- Adds a regression test that enables `next.jdbc.specs/instrument` and exercises a migrate + down cycle, which fails without the fix.

## Test plan
- [x] `lein test :only migratus.test.database/test-mark-not-complete-conforms-to-jdbc-spec` passes with the fix.
- [x] Same test errors with the spec failure when the fix is reverted.