### PR TITLE
Fix init multiple statements 93

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+### 1.6.7
+* parse init script into statements so multiple `--;;` separated statements work across JDBC drivers ([#93](https://github.com/yogthos/migratus/issues/93))
+
 ### 1.6.6
 * [fix mark-not-complete to pass keyword table name](https://github.com/yogthos/migratus/pull/280)
 

--- a/deps.edn
+++ b/deps.edn
@@ -27,4 +27,8 @@
                           lambdaisland/kaocha-cloverage {:mvn/version "1.0.75"}
                           lambdaisland/kaocha-junit-xml {:mvn/version "0.0.76"}
                           orchestra/orchestra           {:mvn/version "2021.01.01-1"}}
+                         ;; docker-java pulled by testcontainers defaults to API 1.32,
+                         ;; which modern Docker daemons reject (min 1.40). Force a supported
+                         ;; version so the testcontainers suite can reach the daemon.
+                         :jvm-opts    ["-Dapi.version=1.41"]
                          :main-opts   ["-m" "kaocha.runner" "--reporter" "kaocha.report/documentation"]}}}

--- a/project.clj
+++ b/project.clj
@@ -16,4 +16,7 @@
                                   [com.h2database/h2 "2.1.214"]
                                   [hikari-cp/hikari-cp "2.13.0"]
                                   [org.clojure/tools.trace "0.7.11"]
-                                  [org.postgresql/postgresql "42.2.5"]]}})
+                                  [org.postgresql/postgresql "42.2.5"]]
+                   ;; testcontainers' docker-java defaults to API 1.32, rejected by
+                   ;; modern Docker daemons (min 1.40); force a supported version.
+                   :jvm-opts ["-Dapi.version=1.41"]}})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject migratus "1.6.6"
+(defproject migratus "1.6.7"
   :description "MIGRATE ALL THE THINGS!"
   :url "http://github.com/yogthos/migratus"
   :license {:name "Apache License, Version 2.0"

--- a/src/migratus/database.clj
+++ b/src/migratus/database.clj
@@ -290,9 +290,11 @@
   (try
     (log/info "running initialization script '" init-script-name "'")
     (log/trace "\n" init-script "\n")
-    ;; Parse the script into statements the same way migrations do, so that
-    ;; multiple statements work regardless of the JDBC driver (see #93).
-    (doseq [command (sql-mig/split-commands init-script nil)]
+    ;; Split the script into individual statements so that multiple statements
+    ;; work regardless of the JDBC driver (see #93). Unlike migrations, the
+    ;; statement text is preserved verbatim (comments are not stripped) so that
+    ;; '--' inside string literals is left intact for the driver to parse.
+    (doseq [command (sql-mig/split-init-commands init-script)]
       (if transaction?
         (jdbc/execute! conn (modify-sql-fn command))
         (jdbc/execute! conn (modify-sql-fn command) {})))

--- a/src/migratus/database.clj
+++ b/src/migratus/database.clj
@@ -290,11 +290,12 @@
   (try
     (log/info "running initialization script '" init-script-name "'")
     (log/trace "\n" init-script "\n")
-    ;; TODO: @ieugen Why was db-do-prepared used here ?
-    ;; Do we need to care about `transaction?` in next.jdbc ?
-    (if transaction?
-      (jdbc/execute! conn (modify-sql-fn init-script))
-      (jdbc/execute! conn (modify-sql-fn init-script) {}))
+    ;; Parse the script into statements the same way migrations do, so that
+    ;; multiple statements work regardless of the JDBC driver (see #93).
+    (doseq [command (sql-mig/split-commands init-script nil)]
+      (if transaction?
+        (jdbc/execute! conn (modify-sql-fn command))
+        (jdbc/execute! conn (modify-sql-fn command) {})))
     (catch Throwable t
       (log/error t "failed to initialize the database with:\n" init-script "\n")
       (throw t))))

--- a/src/migratus/migration/sql.clj
+++ b/src/migratus/migration/sql.clj
@@ -29,6 +29,18 @@
        (remove empty?)
        (not-empty)))
 
+(defn split-init-commands
+  "Split an init script into statements on '--;;' separators. Unlike
+   split-commands, each statement's original text is preserved (comments are
+   NOT stripped), so '--' inside a string literal stays intact and the JDBC
+   driver parses any comments itself. Sections that contain only comments or
+   whitespace are dropped rather than executed as empty statements."
+  [commands]
+  (->> (.split sep commands)
+       (remove #(str/blank? (sanitize % nil)))
+       (map str/trim)
+       (not-empty)))
+
 (defn check-expectations [result c]
   (let [[_full-str expect-str command] (re-matches #"(?sm).*\s*-- expect (.*);;\n+(.*)" c)]
     (assert expect-str (str "No expectation on command: " c))

--- a/test/migrations-postgres/init.sql
+++ b/test/migrations-postgres/init.sql
@@ -1,2 +1,7 @@
+-- comment-only section before the first statement (must be skipped, not run as an empty statement)
+--;;
 CREATE SCHEMA foo;
-CREATE TABLE IF NOT EXISTS foo(id bigint);
+--;;
+CREATE TABLE IF NOT EXISTS foo(id bigint, note varchar(20));
+--;;
+INSERT INTO foo(id, note) VALUES (1, '5--10');

--- a/test/migrations/init-comment-edge.sql
+++ b/test/migrations/init-comment-edge.sql
@@ -1,0 +1,5 @@
+-- comment-only section before the first statement (must be skipped, not run as an empty statement)
+--;;
+CREATE TABLE init_edge (v varchar(20));
+--;;
+INSERT INTO init_edge VALUES ('5--10');

--- a/test/migrations/init-multiple.sql
+++ b/test/migrations/init-multiple.sql
@@ -1,0 +1,4 @@
+-- init script with multiple statements, mirroring issue #93
+CREATE TABLE init_first (id bigint not null primary key);
+--;;
+CREATE TABLE init_second (id bigint not null primary key);

--- a/test/migratus/test/database.clj
+++ b/test/migratus/test/database.clj
@@ -140,6 +140,24 @@
         (proto/init store)
         (is (test-sql/verify-table-exists? config "foo"))))))
 
+(deftest test-init-parses-multiple-statements
+  (testing "init parses the init script the same way migrations do, running each --;; statement separately (#93)"
+    (let [seen (atom [])
+          cfg  (-> config
+                   (assoc :init-script "init-multiple.sql")
+                   (assoc :modify-sql-fn (fn [sql]
+                                           (swap! seen conj sql)
+                                           sql)))]
+      (doseq [init-cfg [cfg (assoc cfg :init-in-transaction? false)]]
+        (test-sql/reset-db)
+        (reset! seen [])
+        (let [store (proto/make-store init-cfg)]
+          (proto/init store)
+          (is (= 2 (count @seen))
+              "init should invoke modify-sql-fn once per --;; statement")
+          (is (test-sql/verify-table-exists? init-cfg "init_first"))
+          (is (test-sql/verify-table-exists? init-cfg "init_second")))))))
+
 (deftest test-migrate
   (is (not (test-sql/verify-table-exists? config "foo")))
   (is (not (test-sql/verify-table-exists? config "bar")))

--- a/test/migratus/test/database.clj
+++ b/test/migratus/test/database.clj
@@ -158,6 +158,17 @@
           (is (test-sql/verify-table-exists? init-cfg "init_first"))
           (is (test-sql/verify-table-exists? init-cfg "init_second")))))))
 
+(deftest test-init-handles-comments-and-literals
+  (testing "init preserves '--' inside string literals and skips comment-only sections (#93)"
+    (let [cfg (assoc config :init-script "init-comment-edge.sql")]
+      (doseq [init-cfg [cfg (assoc cfg :init-in-transaction? false)]]
+        (test-sql/reset-db)
+        (let [store (proto/make-store init-cfg)]
+          (proto/init store)
+          (is (test-sql/verify-table-exists? init-cfg "init_edge"))
+          (is (= [{:v "5--10"}] (verify-data init-cfg "init_edge"))
+              "the '--' inside the string literal must not be stripped as a comment"))))))
+
 (deftest test-migrate
   (is (not (test-sql/verify-table-exists? config "foo")))
   (is (not (test-sql/verify-table-exists? config "bar")))

--- a/test/migratus/test/migration/sql.clj
+++ b/test/migratus/test/migration/sql.clj
@@ -67,6 +67,20 @@
     (is (not (verify-table-exists? config "quux2")))))
 
 
+(deftest test-split-init-commands
+  (testing "splits multiple statements on --;;"
+    (is (= ["CREATE TABLE a (id int);" "CREATE TABLE b (id int);"]
+           (split-init-commands "CREATE TABLE a (id int);\n--;;\nCREATE TABLE b (id int);\n"))))
+  (testing "preserves '--' inside a string literal instead of stripping it"
+    (is (= ["INSERT INTO t VALUES ('5--10');"]
+           (split-init-commands "INSERT INTO t VALUES ('5--10');"))))
+  (testing "drops comment-only sections between separators"
+    (is (= ["CREATE TABLE b (id int);"]
+           (split-init-commands "-- header\n--;;\nCREATE TABLE b (id int);\n"))))
+  (testing "returns nil when nothing executable remains"
+    (is (nil? (split-init-commands "-- just a comment\n")))
+    (is (nil? (split-init-commands "")))))
+
 (comment
   (use 'clojure.tools.trace)
 

--- a/test/migratus/testcontainers/postgres.clj
+++ b/test/migratus/testcontainers/postgres.clj
@@ -8,6 +8,7 @@
             [migratus.test.migration.sql :as test-sql]
             [migratus.core :as migratus]
             [next.jdbc :as jdbc]
+            [next.jdbc.result-set :as rs]
             [next.jdbc.transaction :as jdbc-tx]))
 
 (def postgres-image (or (System/getenv "MIGRATUS_TESTCONTAINERS_POSTGRES_IMAGE") 
@@ -46,6 +47,13 @@
           (let [db-meta (test-sql/db-tables-and-views ds)
                 table-names (meta->table-names db-meta)]
             (is (= #{"foo"} table-names) "db is initialized"))
+          ;; #93: the init script uses --;; separators and a comment-only
+          ;; section, and inserts a value containing '--'. Splitting must run
+          ;; each statement while leaving '--' inside the literal intact.
+          (is (= "5--10"
+                 (:note (jdbc/execute-one! ds ["SELECT note FROM foo WHERE id = 1"]
+                                           {:builder-fn rs/as-unqualified-lower-maps})))
+              "'--' inside the init-script string literal is preserved on postgres")
 
           ;; migrate
           (migratus/migrate config)


### PR DESCRIPTION
addresses splitting for init statements https://github.com/yogthos/migratus/issues/93#issuecomment-4969596592

Init scripts are now split on 1--;;1 like migrations, but keep each statement verbatim so `--` inside string literals survives and comment-only sections are skipped.